### PR TITLE
feat: sidecar effectiveness metrics (v2.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Two problems, one project.
 
 **The solution:** An installer, persistence scripts, and an optional sidecar proxy that handles all of this. Install once, forget about it.
 
+> **v2.2**: Added effectiveness metrics to the sidecar proxy — per-origin kept/dropped counters, score distribution, recidivism stats, and background false-negative detection. Zero config, just upgrade. See [Sidecar Proxy](#sidecar-proxy-optional-but-recommended).
+
 > **v2.1**: Added an intelligent sidecar proxy that scores and prioritizes decisions so the most dangerous threats always make it into your ipset, even when LAPI has 10x more decisions than your device can hold. See [Sidecar Proxy](#sidecar-proxy-optional-but-recommended).
 
 > **v2.0**: Replaced the old Python/Docker bouncer that used the UniFi controller API. That approach hit MongoDB write storms that froze routers at 2000+ IPs. The native bouncer uses ipset and iptables directly — no controller API, no credentials, 15MB process RAM. See [Migration from Python Bouncer](#migration-from-python-bouncer) if upgrading from v1.x.
@@ -344,7 +346,7 @@ Key metrics:
 - `crowdsec_unifi_bouncer_decisions_dropped_total` — Decisions dropped due to capacity
 - `crowdsec_unifi_bouncer_memory_available_kb` — Available system memory
 
-If using the sidecar, it exposes its own metrics at `/metrics` (default port 8084). See [sidecar/README.md](sidecar/README.md#prometheus-metrics) for the full list.
+If using the sidecar, it exposes its own metrics at `/metrics` (default port 8084), including effectiveness metrics (v2.2.0) that show per-origin kept/dropped counts, score distribution, and false-negative detection. See [sidecar/README.md](sidecar/README.md#prometheus-metrics-reference) for the full list.
 
 A Grafana dashboard is included at `grafana/crowdsec-unifi-bouncer-dashboard.json`.
 

--- a/sidecar/cmd/sidecar/main.go
+++ b/sidecar/cmd/sidecar/main.go
@@ -68,6 +68,9 @@ func main() {
 	// Create handler
 	handler := proxy.New(cfg, logger)
 
+	// Start background checks (false-negative detection)
+	handler.StartBackgroundChecks(context.Background())
+
 	// Create server
 	// WriteTimeout must exceed upstream_timeout (default 120s) to allow startup=true
 	// queries against a large CrowdSec DB to complete before the connection is cut.
@@ -94,6 +97,9 @@ func main() {
 	sig := <-quit
 
 	logger.Info("shutting down", "signal", sig.String())
+
+	// Stop background checks
+	handler.StopBackgroundChecks()
 
 	// Graceful shutdown with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/sidecar/config.yaml.example
+++ b/sidecar/config.yaml.example
@@ -109,3 +109,18 @@ health:
 metrics:
   enabled: true
   path: "/metrics"
+
+# Effectiveness metrics (v2.2.0)
+# Controls how scoring effectiveness is measured and reported
+effectiveness:
+  # Number of top scenarios to show individually in metrics
+  # Remaining scenarios are aggregated as "other" to prevent cardinality explosion
+  top_scenarios: 20
+
+  # Background false-negative detection
+  # Periodically queries LAPI for local alerts and cross-references against
+  # dropped IPs. If a dropped IP later attacks your network, it's a false negative.
+  false_negative_check:
+    enabled: true
+    interval: 5m      # How often to check
+    lookback: 15m     # How far back to look for alerts

--- a/sidecar/internal/config/config.go
+++ b/sidecar/internal/config/config.go
@@ -19,9 +19,10 @@ type Config struct {
 	CacheTTL        time.Duration `yaml:"cache_ttl"`
 	UpstreamTimeout time.Duration `yaml:"upstream_timeout"`
 	LogLevel        string        `yaml:"log_level"`
-	Scoring         ScoringConfig `yaml:"scoring"`
-	Health          HealthConfig  `yaml:"health"`
-	Metrics         MetricsConfig `yaml:"metrics"`
+	Scoring         ScoringConfig       `yaml:"scoring"`
+	Health          HealthConfig        `yaml:"health"`
+	Metrics         MetricsConfig       `yaml:"metrics"`
+	Effectiveness   EffectivenessConfig `yaml:"effectiveness"`
 }
 
 // FreshnessBonus awards extra points for recently created decisions.
@@ -77,6 +78,19 @@ type MetricsConfig struct {
 	Path    string `yaml:"path"`
 }
 
+// EffectivenessConfig controls effectiveness metrics collection.
+type EffectivenessConfig struct {
+	TopScenarios       int                 `yaml:"top_scenarios"`
+	FalseNegativeCheck FalseNegativeConfig `yaml:"false_negative_check"`
+}
+
+// FalseNegativeConfig controls the background false-negative detection.
+type FalseNegativeConfig struct {
+	Enabled  bool          `yaml:"enabled"`
+	Interval time.Duration `yaml:"interval"`
+	Lookback time.Duration `yaml:"lookback"`
+}
+
 // Load reads and parses the configuration file.
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
@@ -98,6 +112,14 @@ func Load(path string) (*Config, error) {
 		Metrics: MetricsConfig{
 			Enabled: true,
 			Path:    "/metrics",
+		},
+		Effectiveness: EffectivenessConfig{
+			TopScenarios: 20,
+			FalseNegativeCheck: FalseNegativeConfig{
+				Enabled:  true,
+				Interval: 5 * time.Minute,
+				Lookback: 15 * time.Minute,
+			},
 		},
 		Scoring: ScoringConfig{
 			ScenarioMultiplier: 2.0,

--- a/sidecar/internal/lapi/client_test.go
+++ b/sidecar/internal/lapi/client_test.go
@@ -1,0 +1,141 @@
+package lapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestClient_GetAlerts(t *testing.T) {
+	tests := []struct {
+		name       string
+		response   string
+		statusCode int
+		wantCount  int
+		wantErr    bool
+	}{
+		{
+			name: "successful alert fetch",
+			response: `[
+				{"id":1,"scenario":"crowdsecurity/ssh-bf","source":{"ip":"1.2.3.4","scope":"ip","value":"1.2.3.4"}},
+				{"id":2,"scenario":"crowdsecurity/http-probing","source":{"ip":"5.6.7.8","scope":"ip","value":"5.6.7.8"}}
+			]`,
+			statusCode: http.StatusOK,
+			wantCount:  2,
+		},
+		{
+			name:       "null response",
+			response:   "null",
+			statusCode: http.StatusOK,
+			wantCount:  0,
+		},
+		{
+			name:       "empty array response",
+			response:   "[]",
+			statusCode: http.StatusOK,
+			wantCount:  0,
+		},
+		{
+			name:       "LAPI error",
+			response:   "internal server error",
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/alerts" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				if r.Header.Get("X-Api-Key") != "test-key" {
+					t.Errorf("missing or wrong API key")
+				}
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewClient(server.URL, "test-key", 0)
+			alerts, err := client.GetAlerts(context.Background(), nil)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAlerts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(alerts) != tt.wantCount {
+				t.Errorf("GetAlerts() returned %d alerts, want %d", len(alerts), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestClient_GetAlerts_WithParams(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		since := r.URL.Query().Get("since")
+		if since != "15m0s" {
+			t.Errorf("expected since=15m0s, got %s", since)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"id":1,"scenario":"ssh-bf","source":{"ip":"1.2.3.4","scope":"ip","value":"1.2.3.4"}}]`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key", 0)
+	params := url.Values{}
+	params.Set("since", "15m0s")
+
+	alerts, err := client.GetAlerts(context.Background(), params)
+	if err != nil {
+		t.Fatalf("GetAlerts() error = %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Errorf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].Source.IP != "1.2.3.4" {
+		t.Errorf("expected source IP 1.2.3.4, got %s", alerts[0].Source.IP)
+	}
+}
+
+func TestClient_GetAlerts_ParsesFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{
+			"id": 42,
+			"scenario": "crowdsecurity/ssh-bf",
+			"source": {
+				"ip": "10.0.0.1",
+				"scope": "ip",
+				"value": "10.0.0.1"
+			}
+		}]`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key", 0)
+	alerts, err := client.GetAlerts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GetAlerts() error = %v", err)
+	}
+
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+
+	alert := alerts[0]
+	if alert.ID != 42 {
+		t.Errorf("ID = %d, want 42", alert.ID)
+	}
+	if alert.Scenario != "crowdsecurity/ssh-bf" {
+		t.Errorf("Scenario = %s, want crowdsecurity/ssh-bf", alert.Scenario)
+	}
+	if alert.Source.IP != "10.0.0.1" {
+		t.Errorf("Source.IP = %s, want 10.0.0.1", alert.Source.IP)
+	}
+	if alert.Source.Scope != "ip" {
+		t.Errorf("Source.Scope = %s, want ip", alert.Source.Scope)
+	}
+}

--- a/sidecar/internal/proxy/handler.go
+++ b/sidecar/internal/proxy/handler.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/config"
@@ -37,6 +40,18 @@ type Handler struct {
 	failedRequests   int64
 	upstreamLatency  time.Duration
 	lastUpstreamCall time.Time
+
+	// Effectiveness tracking
+	droppedIPs   map[string]struct{}
+	droppedIPsMu sync.RWMutex
+
+	// False-negative detection
+	falseNegativesTotal    atomic.Int64
+	falseNegativeLastCheck atomic.Int64 // unix timestamp
+
+	// Background checks
+	bgCancel context.CancelFunc
+	bgWg     sync.WaitGroup
 }
 
 // New creates a new Handler.
@@ -159,7 +174,17 @@ func (h *Handler) handleDecisionsStream(w http.ResponseWriter, r *http.Request) 
 
 	// Score and truncate new decisions
 	if len(stream.New) > 0 {
-		stream.New, _ = h.scorer.ScoreAndTruncateWithStats(stream.New, h.cfg.MaxDecisions)
+		var stats scorer.Stats
+		stream.New, stats = h.scorer.ScoreAndTruncateWithStats(stream.New, h.cfg.MaxDecisions)
+
+		// Store stats and dropped IPs from stream scoring
+		h.droppedIPsMu.Lock()
+		h.droppedIPs = stats.DroppedIPs
+		h.droppedIPsMu.Unlock()
+
+		h.cacheMu.Lock()
+		h.cacheStats = stats
+		h.cacheMu.Unlock()
 	}
 
 	h.logger.Info("processed decision stream",
@@ -216,7 +241,14 @@ func (h *Handler) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	cacheStats := h.cacheStats
 	h.cacheMu.RUnlock()
 
+	topN := h.cfg.Effectiveness.TopScenarios
+	if topN <= 0 {
+		topN = 20
+	}
+
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+
+	// --- Operational metrics (existing) ---
 
 	fmt.Fprintf(w, "# HELP crowdsec_sidecar_requests_total Total number of requests\n")
 	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_requests_total counter\n")
@@ -257,6 +289,226 @@ func (h *Handler) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "# HELP crowdsec_sidecar_uptime_seconds Time since sidecar started\n")
 	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_uptime_seconds gauge\n")
 	fmt.Fprintf(w, "crowdsec_sidecar_uptime_seconds %.0f\n", time.Since(h.startTime).Seconds())
+
+	// --- Effectiveness metrics (v2.2.0) ---
+
+	// Per-origin kept/dropped
+	fmt.Fprintf(w, "# HELP crowdsec_sidecar_decisions_kept Decisions kept per origin\n")
+	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_decisions_kept gauge\n")
+	for origin, count := range cacheStats.OriginKept {
+		fmt.Fprintf(w, "crowdsec_sidecar_decisions_kept{origin=%q} %d\n", origin, count)
+	}
+
+	fmt.Fprintf(w, "# HELP crowdsec_sidecar_decisions_dropped_by_origin Decisions dropped per origin\n")
+	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_decisions_dropped_by_origin gauge\n")
+	for origin, count := range cacheStats.OriginDropped {
+		fmt.Fprintf(w, "crowdsec_sidecar_decisions_dropped_by_origin{origin=%q} %d\n", origin, count)
+	}
+
+	// Per-scenario kept/dropped (top N with "other" aggregation)
+	h.writeTopNMetric(w,
+		"crowdsec_sidecar_scenario_kept",
+		"Decisions kept per scenario (top N)",
+		"gauge",
+		cacheStats.ScenarioKept, topN)
+
+	h.writeTopNMetric(w,
+		"crowdsec_sidecar_scenario_dropped",
+		"Decisions dropped per scenario (top N)",
+		"gauge",
+		cacheStats.ScenarioDropped, topN)
+
+	// Score distribution
+	fmt.Fprintf(w, "# HELP crowdsec_sidecar_score_cutoff Lowest score that survived truncation\n")
+	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_score_cutoff gauge\n")
+	fmt.Fprintf(w, "crowdsec_sidecar_score_cutoff %d\n", cacheStats.ScoreCutoff)
+
+	fmt.Fprintf(w, "# HELP crowdsec_sidecar_score_max Highest decision score\n")
+	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_score_max gauge\n")
+	fmt.Fprintf(w, "crowdsec_sidecar_score_max %d\n", cacheStats.MaxScore)
+
+	fmt.Fprintf(w, "# HELP crowdsec_sidecar_score_median Median decision score\n")
+	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_score_median gauge\n")
+	fmt.Fprintf(w, "crowdsec_sidecar_score_median %d\n", cacheStats.MedianScore)
+
+	fmt.Fprintf(w, "# HELP crowdsec_sidecar_score_bucket Cumulative score distribution\n")
+	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_score_bucket gauge\n")
+	for _, threshold := range scorer.ScoreBucketThresholds {
+		count := cacheStats.ScoreBuckets[threshold]
+		fmt.Fprintf(w, "crowdsec_sidecar_score_bucket{le=\"%d\"} %d\n", threshold, count)
+	}
+
+	// Recidivism stats
+	fmt.Fprintf(w, "# HELP crowdsec_sidecar_recidivism_ips Unique IPs with recidivism bonus\n")
+	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_recidivism_ips gauge\n")
+	fmt.Fprintf(w, "crowdsec_sidecar_recidivism_ips %d\n", cacheStats.RecidivismIPs)
+
+	fmt.Fprintf(w, "# HELP crowdsec_sidecar_recidivism_boosts Total recidivism bonus points applied\n")
+	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_recidivism_boosts gauge\n")
+	fmt.Fprintf(w, "crowdsec_sidecar_recidivism_boosts %d\n", cacheStats.RecidivismBoosts)
+
+	// False-negative detection
+	fmt.Fprintf(w, "# HELP crowdsec_sidecar_false_negatives_total IPs that were dropped but later attacked locally\n")
+	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_false_negatives_total counter\n")
+	fmt.Fprintf(w, "crowdsec_sidecar_false_negatives_total %d\n", h.falseNegativesTotal.Load())
+
+	fmt.Fprintf(w, "# HELP crowdsec_sidecar_false_negative_check_time Unix timestamp of last false-negative check\n")
+	fmt.Fprintf(w, "# TYPE crowdsec_sidecar_false_negative_check_time gauge\n")
+	fmt.Fprintf(w, "crowdsec_sidecar_false_negative_check_time %d\n", h.falseNegativeLastCheck.Load())
+}
+
+// writeTopNMetric writes a Prometheus metric for the top N entries of a map,
+// aggregating the rest under "other".
+func (h *Handler) writeTopNMetric(w http.ResponseWriter, name, help, metricType string, data map[string]int, n int) {
+	fmt.Fprintf(w, "# HELP %s %s\n", name, help)
+	fmt.Fprintf(w, "# TYPE %s %s\n", name, metricType)
+
+	if len(data) == 0 {
+		return
+	}
+
+	// Sort by count descending
+	type kv struct {
+		key   string
+		value int
+	}
+	sorted := make([]kv, 0, len(data))
+	for k, v := range data {
+		sorted = append(sorted, kv{k, v})
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].value > sorted[j].value
+	})
+
+	// Emit top N
+	otherCount := 0
+	for i, entry := range sorted {
+		if i < n {
+			fmt.Fprintf(w, "%s{scenario=%q} %d\n", name, entry.key, entry.value)
+		} else {
+			otherCount += entry.value
+		}
+	}
+
+	// Emit "other" if there are overflow entries
+	if otherCount > 0 {
+		fmt.Fprintf(w, "%s{scenario=\"other\"} %d\n", name, otherCount)
+	}
+}
+
+// StartBackgroundChecks starts the false-negative checker goroutine.
+func (h *Handler) StartBackgroundChecks(ctx context.Context) {
+	if !h.cfg.Effectiveness.FalseNegativeCheck.Enabled {
+		h.logger.Info("false-negative checker disabled")
+		return
+	}
+
+	bgCtx, cancel := context.WithCancel(ctx)
+	h.bgCancel = cancel
+
+	h.bgWg.Add(1)
+	go h.falseNegativeChecker(bgCtx)
+
+	h.logger.Info("false-negative checker started",
+		"interval", h.cfg.Effectiveness.FalseNegativeCheck.Interval,
+		"lookback", h.cfg.Effectiveness.FalseNegativeCheck.Lookback,
+	)
+}
+
+// StopBackgroundChecks stops background goroutines and waits for them to finish.
+func (h *Handler) StopBackgroundChecks() {
+	if h.bgCancel != nil {
+		h.bgCancel()
+	}
+	h.bgWg.Wait()
+}
+
+// falseNegativeChecker periodically checks for false negatives.
+func (h *Handler) falseNegativeChecker(ctx context.Context) {
+	defer h.bgWg.Done()
+
+	interval := h.cfg.Effectiveness.FalseNegativeCheck.Interval
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			h.logger.Info("false-negative checker stopped")
+			return
+		case <-ticker.C:
+			h.runFalseNegativeCheck(ctx)
+		}
+	}
+}
+
+// runFalseNegativeCheck queries LAPI for recent local alerts and cross-references
+// against dropped IPs. If a dropped IP later generated an alert, it's a false negative.
+func (h *Handler) runFalseNegativeCheck(ctx context.Context) {
+	// Get current dropped IPs
+	h.droppedIPsMu.RLock()
+	dropped := h.droppedIPs
+	h.droppedIPsMu.RUnlock()
+
+	if len(dropped) == 0 {
+		h.falseNegativeLastCheck.Store(time.Now().Unix())
+		h.logger.Debug("false-negative check: no dropped IPs to check")
+		return
+	}
+
+	// Query LAPI for recent alerts
+	lookback := h.cfg.Effectiveness.FalseNegativeCheck.Lookback
+	if lookback <= 0 {
+		lookback = 15 * time.Minute
+	}
+
+	params := url.Values{}
+	params.Set("since", lookback.String())
+
+	alerts, err := h.client.GetAlerts(ctx, params)
+	if err != nil {
+		h.logger.Warn("false-negative check: failed to fetch alerts", "error", err)
+		return
+	}
+
+	// Cross-reference alert source IPs against dropped IPs
+	fnCount := 0
+	for _, alert := range alerts {
+		ip := alert.Source.Value
+		if ip == "" {
+			ip = alert.Source.IP
+		}
+		if ip == "" {
+			continue
+		}
+		if _, wasDropped := dropped[ip]; wasDropped {
+			fnCount++
+			h.logger.Warn("false-negative detected",
+				"ip", ip,
+				"scenario", alert.Scenario,
+				"alert_id", alert.ID,
+			)
+		}
+	}
+
+	if fnCount > 0 {
+		h.falseNegativesTotal.Add(int64(fnCount))
+		h.logger.Warn("false-negative check: found false negatives",
+			"count", fnCount,
+			"total", h.falseNegativesTotal.Load(),
+		)
+	} else {
+		h.logger.Debug("false-negative check clean",
+			"alerts_checked", len(alerts),
+			"dropped_ips", len(dropped),
+		)
+	}
+
+	h.falseNegativeLastCheck.Store(time.Now().Unix())
 }
 
 // proxyPassthrough proxies requests directly to upstream without modification.
@@ -323,15 +575,19 @@ func (h *Handler) getCachedDecisions() ([]lapi.Decision, scorer.Stats, bool) {
 	return nil, scorer.Stats{}, false
 }
 
-// setCachedDecisions updates the cache.
+// setCachedDecisions updates the cache and stores dropped IPs for false-negative checking.
 func (h *Handler) setCachedDecisions(decisions []lapi.Decision, stats scorer.Stats) {
 	h.cacheMu.Lock()
-	defer h.cacheMu.Unlock()
-
 	h.cache = decisions
 	h.cacheTime = time.Now()
 	h.cacheStats = stats
 	h.cacheMisses++
+	h.cacheMu.Unlock()
+
+	// Store dropped IPs for false-negative checking
+	h.droppedIPsMu.Lock()
+	h.droppedIPs = stats.DroppedIPs
+	h.droppedIPsMu.Unlock()
 }
 
 // fetchAndScoreDecisions fetches from upstream, scores, and truncates.

--- a/sidecar/internal/proxy/handler_test.go
+++ b/sidecar/internal/proxy/handler_test.go
@@ -1,0 +1,354 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/config"
+	"github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/lapi"
+	"github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/scorer"
+)
+
+func testConfig(lapiURL string) *config.Config {
+	return &config.Config{
+		ListenAddr:      "127.0.0.1:0",
+		UpstreamLAPIURL: lapiURL,
+		UpstreamLAPIKey: "test-key",
+		MaxDecisions:    3,
+		CacheTTL:        60 * time.Second,
+		UpstreamTimeout: 10 * time.Second,
+		LogLevel:        "debug",
+		Scoring: config.ScoringConfig{
+			Scenarios: map[string]int{
+				"ssh-bf":  50,
+				"default": 10,
+			},
+			Origins: map[string]int{
+				"crowdsec": 25,
+				"CAPI":     10,
+			},
+			ScenarioMultiplier: 2.0,
+			RecidivismBonus:    15,
+			TTLScoring:         config.TTLScoringConfig{Enabled: false},
+			DecisionTypes: map[string]int{
+				"ban": 5,
+			},
+		},
+		Health: config.HealthConfig{
+			Enabled: true,
+			Path:    "/health",
+		},
+		Metrics: config.MetricsConfig{
+			Enabled: true,
+			Path:    "/metrics",
+		},
+		Effectiveness: config.EffectivenessConfig{
+			TopScenarios: 20,
+			FalseNegativeCheck: config.FalseNegativeConfig{
+				Enabled:  true,
+				Interval: 1 * time.Second,
+				Lookback: 15 * time.Minute,
+			},
+		},
+	}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+}
+
+func TestHandler_MetricsContainsEffectivenessMetrics(t *testing.T) {
+	decisions := []lapi.Decision{
+		{ID: 1, Scenario: "ssh-bf", Origin: "crowdsec", Type: "ban", Scope: "ip", Value: "1.1.1.1"},
+		{ID: 2, Scenario: "ssh-bf", Origin: "CAPI", Type: "ban", Scope: "ip", Value: "2.2.2.2"},
+		{ID: 3, Scenario: "default", Origin: "CAPI", Type: "ban", Scope: "ip", Value: "3.3.3.3"},
+		{ID: 4, Scenario: "default", Origin: "CAPI", Type: "ban", Scope: "ip", Value: "4.4.4.4"},
+		{ID: 5, Scenario: "default", Origin: "CAPI", Type: "ban", Scope: "ip", Value: "5.5.5.5"},
+	}
+
+	// Mock LAPI server
+	lapiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/decisions":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(decisions)
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer lapiServer.Close()
+
+	cfg := testConfig(lapiServer.URL)
+	handler := New(cfg, testLogger())
+
+	// First, trigger a decisions fetch to populate cache stats
+	req := httptest.NewRequest("GET", "/v1/decisions", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("decisions request failed: %d", rr.Code)
+	}
+
+	// Now fetch metrics
+	req = httptest.NewRequest("GET", "/metrics", nil)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("metrics request failed: %d", rr.Code)
+	}
+
+	body := rr.Body.String()
+
+	// Check existing operational metrics
+	expectedMetrics := []string{
+		"crowdsec_sidecar_requests_total",
+		"crowdsec_sidecar_decisions_total",
+		"crowdsec_sidecar_decisions_dropped",
+	}
+
+	// Check new effectiveness metrics
+	effectivenessMetrics := []string{
+		"crowdsec_sidecar_decisions_kept{origin=",
+		"crowdsec_sidecar_decisions_dropped_by_origin{origin=",
+		"crowdsec_sidecar_scenario_kept{scenario=",
+		"crowdsec_sidecar_scenario_dropped{scenario=",
+		"crowdsec_sidecar_score_cutoff",
+		"crowdsec_sidecar_score_max",
+		"crowdsec_sidecar_score_median",
+		"crowdsec_sidecar_score_bucket{le=",
+		"crowdsec_sidecar_recidivism_ips",
+		"crowdsec_sidecar_recidivism_boosts",
+		"crowdsec_sidecar_false_negatives_total",
+		"crowdsec_sidecar_false_negative_check_time",
+	}
+
+	for _, metric := range append(expectedMetrics, effectivenessMetrics...) {
+		if !strings.Contains(body, metric) {
+			t.Errorf("metrics output missing %q", metric)
+		}
+	}
+
+	// Verify specific values
+	// 5 total decisions, max 3 kept, so 2 dropped
+	if !strings.Contains(body, "crowdsec_sidecar_decisions_total 5") {
+		t.Error("expected decisions_total 5")
+	}
+	if !strings.Contains(body, "crowdsec_sidecar_decisions_dropped 2") {
+		t.Error("expected decisions_dropped 2")
+	}
+
+	// crowdsec origin: 1 kept (ssh-bf scores highest), 0 dropped
+	if !strings.Contains(body, `crowdsec_sidecar_decisions_kept{origin="crowdsec"} 1`) {
+		t.Error("expected crowdsec origin kept=1")
+	}
+
+	// false negatives should be 0
+	if !strings.Contains(body, "crowdsec_sidecar_false_negatives_total 0") {
+		t.Error("expected false_negatives_total 0")
+	}
+}
+
+func TestHandler_FalseNegativeDetection(t *testing.T) {
+	alertsServed := false
+
+	// Mock LAPI: serves decisions and alerts
+	lapiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/decisions":
+			decisions := []lapi.Decision{
+				{ID: 1, Scenario: "ssh-bf", Origin: "crowdsec", Type: "ban", Scope: "ip", Value: "1.1.1.1"},
+				{ID: 2, Scenario: "default", Origin: "CAPI", Type: "ban", Scope: "ip", Value: "2.2.2.2"},
+				{ID: 3, Scenario: "default", Origin: "CAPI", Type: "ban", Scope: "ip", Value: "3.3.3.3"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(decisions)
+		case "/v1/alerts":
+			alertsServed = true
+			// Return an alert for an IP that was dropped (3.3.3.3 will be dropped with max_decisions=2)
+			alerts := []lapi.Alert{
+				{ID: 100, Scenario: "crowdsecurity/ssh-bf", Source: lapi.AlertSource{IP: "3.3.3.3", Scope: "ip", Value: "3.3.3.3"}},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(alerts)
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer lapiServer.Close()
+
+	cfg := testConfig(lapiServer.URL)
+	cfg.MaxDecisions = 2 // Keep only 2 of 3 decisions
+	handler := New(cfg, testLogger())
+
+	// Trigger a decisions fetch to populate droppedIPs
+	req := httptest.NewRequest("GET", "/v1/decisions", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("decisions request failed: %d", rr.Code)
+	}
+
+	// Verify droppedIPs is populated
+	handler.droppedIPsMu.RLock()
+	droppedCount := len(handler.droppedIPs)
+	handler.droppedIPsMu.RUnlock()
+
+	if droppedCount == 0 {
+		t.Fatal("expected droppedIPs to be populated after decisions fetch")
+	}
+
+	// Run false-negative check manually
+	handler.runFalseNegativeCheck(context.Background())
+
+	if !alertsServed {
+		t.Fatal("expected LAPI alerts endpoint to be queried")
+	}
+
+	// Check if false negative was detected
+	fnTotal := handler.falseNegativesTotal.Load()
+	if fnTotal != 1 {
+		t.Errorf("expected 1 false negative, got %d", fnTotal)
+	}
+
+	// Check that last check time was updated
+	lastCheck := handler.falseNegativeLastCheck.Load()
+	if lastCheck == 0 {
+		t.Error("expected falseNegativeLastCheck to be updated")
+	}
+}
+
+func TestHandler_FalseNegativeNoDroppedIPs(t *testing.T) {
+	lapiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/alerts":
+			t.Error("alerts endpoint should not be called when no dropped IPs")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer lapiServer.Close()
+
+	cfg := testConfig(lapiServer.URL)
+	handler := New(cfg, testLogger())
+
+	// Run check with no dropped IPs — should skip LAPI query
+	handler.runFalseNegativeCheck(context.Background())
+
+	lastCheck := handler.falseNegativeLastCheck.Load()
+	if lastCheck == 0 {
+		t.Error("expected falseNegativeLastCheck to be updated even with no dropped IPs")
+	}
+}
+
+func TestHandler_BackgroundChecksLifecycle(t *testing.T) {
+	lapiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+	defer lapiServer.Close()
+
+	cfg := testConfig(lapiServer.URL)
+	cfg.Effectiveness.FalseNegativeCheck.Interval = 100 * time.Millisecond
+	handler := New(cfg, testLogger())
+
+	// Start background checks
+	handler.StartBackgroundChecks(context.Background())
+
+	// Let it run a couple ticks
+	time.Sleep(350 * time.Millisecond)
+
+	// Stop should not hang
+	done := make(chan struct{})
+	go func() {
+		handler.StopBackgroundChecks()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopBackgroundChecks timed out")
+	}
+}
+
+func TestHandler_MetricsTopNAggregation(t *testing.T) {
+	// Create a handler with pre-populated cache stats that have many scenarios
+	lapiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer lapiServer.Close()
+
+	cfg := testConfig(lapiServer.URL)
+	cfg.Effectiveness.TopScenarios = 2 // Only show top 2
+	handler := New(cfg, testLogger())
+
+	// Manually populate cache stats
+	handler.cacheMu.Lock()
+	handler.cacheStats = scorer.Stats{
+		TotalDecisions:    100,
+		ReturnedDecisions: 50,
+		DroppedDecisions:  50,
+		ScenarioKept: map[string]int{
+			"ssh-bf":       20,
+			"http-probing": 15,
+			"http-sqli":    10,
+			"default":      5,
+		},
+		ScenarioDropped: map[string]int{
+			"default":           30,
+			"http-bad-ua":       15,
+			"http-path-trav":    5,
+		},
+		OriginKept:    map[string]int{"crowdsec": 20, "CAPI": 30},
+		OriginDropped: map[string]int{"CAPI": 50},
+		ScoreBuckets:  map[int]int{25: 10, 50: 30, 75: 60, 100: 80, 150: 95, 200: 100},
+		DroppedIPs:    make(map[string]struct{}),
+	}
+	handler.cacheMu.Unlock()
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+
+	// Top 2 kept scenarios should be ssh-bf (20) and http-probing (15)
+	if !strings.Contains(body, `crowdsec_sidecar_scenario_kept{scenario="ssh-bf"} 20`) {
+		t.Error("expected ssh-bf in top N kept")
+	}
+	if !strings.Contains(body, `crowdsec_sidecar_scenario_kept{scenario="http-probing"} 15`) {
+		t.Error("expected http-probing in top N kept")
+	}
+	// Remaining should be aggregated as "other" = 10 + 5 = 15
+	if !strings.Contains(body, `crowdsec_sidecar_scenario_kept{scenario="other"} 15`) {
+		t.Error("expected 'other' aggregation = 15 for kept scenarios")
+	}
+
+	// Top 2 dropped scenarios should be default (30) and http-bad-ua (15)
+	if !strings.Contains(body, `crowdsec_sidecar_scenario_dropped{scenario="default"} 30`) {
+		t.Error("expected default in top N dropped")
+	}
+	// "other" for dropped = 5
+	if !strings.Contains(body, `crowdsec_sidecar_scenario_dropped{scenario="other"} 5`) {
+		t.Error("expected 'other' aggregation = 5 for dropped scenarios")
+	}
+}


### PR DESCRIPTION
## Summary

Adds effectiveness metrics to the sidecar proxy's existing `/metrics` endpoint. Users get visibility into what the scoring system is keeping/dropping with zero configuration — just upgrade the sidecar.

**Context:** v2.1.0 added 7-factor scoring that filters 125K LAPI decisions down to 38K for our devices. It works — 100% of local detections preserved — but there was no way to continuously verify this. These metrics fix that.

### New Metrics

- **Per-origin kept/dropped** — See at a glance: "100% of my `crowdsec` detections survived"
- **Per-scenario kept/dropped** (top 20) — Which threat types survive vs get filtered, with "other" aggregation to prevent cardinality explosion
- **Score distribution** — cutoff, max, median, and histogram buckets (25/50/75/100/150/200)
- **Recidivism stats** — Proves repeat-offender promotion is working
- **False-negative detection** — Background checker queries LAPI for local alerts and cross-references against dropped IPs. If a dropped IP later attacks, counter increments. Should always be 0.

### Example Output

\`\`\`
crowdsec_sidecar_decisions_kept{origin="crowdsec"} 268
crowdsec_sidecar_decisions_kept{origin="CAPI"} 10239
crowdsec_sidecar_decisions_dropped_by_origin{origin="blocklist-import"} 87321
crowdsec_sidecar_score_cutoff 35
crowdsec_sidecar_score_median 76
crowdsec_sidecar_recidivism_ips 355
crowdsec_sidecar_false_negatives_total 0
\`\`\`

### Configuration (optional)

\`\`\`yaml
effectiveness:
  top_scenarios: 20
  false_negative_check:
    enabled: true
    interval: 5m
    lookback: 15m
\`\`\`

All defaults are sane — no config changes needed to get all metrics.

## Files Changed

| File | What |
|------|------|
| scorer.go | Extended Stats struct with origin/scenario/score/recidivism/dropped tracking |
| config.go | Added EffectivenessConfig with false-negative check settings |
| lapi/client.go | Added Alert struct and GetAlerts() for false-negative detection |
| proxy/handler.go | Effectiveness tracking, false-negative goroutine, expanded metrics output |
| cmd/sidecar/main.go | Wire up StartBackgroundChecks/StopBackgroundChecks |
| *_test.go | 30 tests pass with -race, including new effectiveness and handler tests |
| READMEs + config.yaml.example | Full documentation of new metrics and config |

## Seeking Feedback

- Are these the right metrics for understanding scoring effectiveness?
- Is the false-negative detection approach sound? (Query local alerts, cross-ref against dropped IPs)
- Any concerns about the top-N scenario aggregation approach?
- Anything missing that would help you tune your scoring config?

## Test Plan

- [x] go test -race ./... — 30 tests pass, 0 failures
- [x] go build ./cmd/sidecar — builds clean
- [ ] Deploy to production, verify /metrics output matches expected values
- [ ] Verify false-negative checker runs (check logs for "false-negative check clean")
- [ ] Update Grafana dashboard with new panels

🤖 *This PR was generated by Claude AI assisting the maintainer.*