### PR TITLE
Auto-detect device model and set appropriate ipset limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,90 @@ Two problems, one project.
 
 > **v2.0**: Replaced the old Python/Docker bouncer that used the UniFi controller API. That approach hit MongoDB write storms that froze routers at 2000+ IPs. The native bouncer uses ipset and iptables directly — no controller API, no credentials, 15MB process RAM. See [Migration from Python Bouncer](#migration-from-python-bouncer) if upgrading from v1.x.
 
-## Device Defaults
+## Device Compatibility & Defaults
 
-The bouncer auto-detects your UniFi device and applies tested defaults:
+The bouncer auto-detects your UniFi device model on startup and applies safe default ipset limits based on [Ubiquiti's CyberSecure IPS signature capacity specifications](https://help.ui.com/hc/en-us/articles/25930305913751).
 
-| Device | Default ipset | RAM | Recommended Sidecar Cap |
-|--------|---------------|-----|-------------------------|
-| UDM Pro Max | 30,000 IPs | 8GB | 28,000 |
-| UDM Pro / SE | 20,000 IPs | 4GB | 18,000 |
-| UDR / UCG | 15,000 IPs | 2GB | 13,000 |
-| UniFi Express | 10,000 IPs | 1GB | 8,000 |
+Detection methods (tried in order):
+1. `ubnt-device-info model` — most reliable on UniFi OS 3+
+2. `/proc/ubnthal/system.info` shortname field
+3. `/etc/unifi-os/unifi_version` model field
+4. `/sys/firmware/devicetree/base/model` device tree
+5. `dmesg` pattern matching (last resort)
 
-These limits balance protection coverage with device stability. The "Recommended Sidecar Cap" leaves 2,000 entries of headroom for manual bans and edge cases.
+### Device Capacity Matrix
+
+| Model | Tier | Default ipset | Memory Optimized | Sidecar Cap |
+|-------|------|---------------|------------------|-------------|
+| EFG | Enterprise | 80,000 | — | 78,000 |
+| UXG-Enterprise | Enterprise | 80,000 | — | 78,000 |
+| UDM-Pro-Max | Pro | 50,000 | 30,000 | 48,000 |
+| UDM-SE | Pro | 50,000 | 30,000 | 48,000 |
+| UDM-Pro | Pro | 50,000 | 30,000 | 48,000 |
+| UDW | Pro | 50,000 | 30,000 | 48,000 |
+| UCG-Max | Pro | 50,000 | 30,000 | 48,000 |
+| UCG-Ultra | Pro | 50,000 | 30,000 | 48,000 |
+| UCG-Fiber | Pro | 50,000 | 30,000 | 48,000 |
+| UXG-Max | Pro | 50,000 | 30,000 | 48,000 |
+| UXG-Pro | Pro | 50,000 | 30,000 | 48,000 |
+| UXG-Fiber | Pro | 50,000 | 30,000 | 48,000 |
+| UDM | Consumer | 15,000 | — | 13,000 |
+| UDR | Consumer | 15,000 | — | 13,000 |
+| UDR7 | Consumer | 15,000 | — | 13,000 |
+| UX7 | Consumer | 15,000 | — | 13,000 |
+| UX | **Unsupported** | — | — | — |
+| UXG-Lite | **Unsupported** | — | — | — |
+| Unknown device | — | 10,000 | — | 8,000 |
+
+"Sidecar Cap" = recommended `max_decisions` for the sidecar proxy, leaving 2,000 entries of headroom for manual bans.
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MAXELEM_OVERRIDE` | Manual override for ipset maxelem. Bypasses auto-detection. Logs a warning if it exceeds the recommended limit for your device. | Auto-detected |
+| `MEMORY_OPTIMIZED` | Set to `true` to use reduced limits for devices running BGP, ad-blocking, content filtering, or multiple UniFi applications. | `false` |
+
+### Usage Scenarios
+
+**Scenario 1: Default (auto-detect, safe limits)**
+```bash
+# No configuration needed — bouncer auto-detects and uses safe defaults
+systemctl start crowdsec-firewall-bouncer
+```
+
+**Scenario 2: Power user (higher limits)**
+
+For users NOT running Protect, Talk, Access, BGP, ad-blocking, or content filtering:
+```bash
+# Override auto-detected limit
+MAXELEM_OVERRIDE=70000 /data/crowdsec-bouncer/setup.sh
+```
+
+**Scenario 3: Memory constrained**
+
+For devices running BGP, ad-blocking, content filtering, or multiple UniFi applications:
+```bash
+MEMORY_OPTIMIZED=true /data/crowdsec-bouncer/setup.sh
+```
+
+**Scenario 4: Unknown device**
+```
+[WARNING] Could not detect device model, using conservative limit of 10000
+[INFO] Set MAXELEM_OVERRIDE to specify a higher limit if needed
+[INFO] Using ipset maxelem: 10000
+```
+
+**Scenario 5: Unsupported device**
+```
+[ERROR] Detected device model: UXG-Lite
+[ERROR] This device does not support firewall groups/ipsets
+[ERROR] crowdsec-unifi-bouncer cannot run on this device
+```
 
 ### Custom Limits
 
-To use a different limit, set `ipset_size` in the bouncer config. Higher values increase memory usage and packet processing time. If using the sidecar, set `max_decisions` in the sidecar config instead.
+To use a different limit, set `MAXELEM_OVERRIDE` as an environment variable before starting the bouncer. If using the sidecar, also set `max_decisions` in the sidecar config to match (`MAXELEM_OVERRIDE - 2000`).
 
 ## What's Included
 

--- a/detect-device.sh
+++ b/detect-device.sh
@@ -1,53 +1,125 @@
 #!/bin/bash
 # CrowdSec Firewall Bouncer - UniFi Device Detection
 # Detects device model and sets safe ipset maxelem defaults
+# Based on Ubiquiti CyberSecure IPS signature capacity specifications
 #
-# Usage: source detect-device.sh   # Sets DETECTED_MODEL and SAFE_MAXELEM
+# Usage: source detect-device.sh   # Sets DETECTED_MODEL, SAFE_MAXELEM, etc.
 #    or: ./detect-device.sh        # Prints detection info
+#
+# Environment variables:
+#   MAXELEM_OVERRIDE   - Manual override for ipset maxelem (bypasses auto-detection)
+#   MEMORY_OPTIMIZED   - Set to "true" for reduced limits on memory-constrained devices
 
-# Safe defaults that work reliably on each device type
-# Override with ipset_size in config for custom values
+# Device limits based on Ubiquiti CyberSecure IPS signature capacities
+# Source: https://help.ui.com/hc/en-us/articles/25930305913751
+#
+# Device model shortnames -> recommended ipset maxelem
+# These are conservative values (below max signatures) for stability
 declare -A DEVICE_MAXELEM=(
-    ["UniFi Dream Machine Pro"]=20000
-    ["UniFi Dream Machine SE"]=20000
-    ["UniFi Dream Machine Pro Max"]=30000
-    ["UniFi Dream Router"]=15000
-    ["UniFi Cloud Gateway Fiber"]=15000
-    ["UniFi Cloud Gateway Ultra"]=15000
-    ["UniFi Express"]=10000
-    ["UniFi Dream Machine"]=15000
+    # Enterprise tier (95k+ signatures)
+    ["EFG"]=80000
+    ["UXG-Enterprise"]=80000
+
+    # Pro tier (55k+ signatures)
+    ["UDM-Pro-Max"]=50000
+    ["UDMPRO-Max"]=50000
+    ["UDM-SE"]=50000
+    ["UDMSE"]=50000
+    ["UDM-Pro"]=50000
+    ["UDMPRO"]=50000
+    ["UDW"]=50000
+    ["UCG-Max"]=50000
+    ["UCG-Ultra"]=50000
+    ["UCG-Fiber"]=50000
+    ["UXG-Max"]=50000
+    ["UXG-Pro"]=50000
+    ["UXG-Fiber"]=50000
+
+    # Consumer tier (20k+ signatures)
+    ["UDM"]=15000
+    ["UDR"]=15000
+    ["UDR7"]=15000
+    ["UX7"]=15000
+
+    # Unsupported (no firewall group/ipset support)
+    ["UX"]=0
+    ["UXG-Lite"]=0
 )
 
-DEFAULT_MAXELEM=20000
+# Memory optimized limits for devices running BGP, ad-blocking,
+# content filtering, or multiple UniFi applications
+declare -A MEMORY_OPTIMIZED_LIMITS=(
+    ["UDM-Pro-Max"]=30000
+    ["UDMPRO-Max"]=30000
+    ["UDM-SE"]=30000
+    ["UDMSE"]=30000
+    ["UDM-Pro"]=30000
+    ["UDMPRO"]=30000
+    ["UDW"]=30000
+    ["UCG-Max"]=30000
+    ["UCG-Ultra"]=30000
+    ["UCG-Fiber"]=30000
+    ["UXG-Max"]=30000
+    ["UXG-Pro"]=30000
+    ["UXG-Fiber"]=30000
+)
+
+# Conservative fallback for unknown devices
+DEFAULT_MAXELEM=10000
+
+# Device tier names for logging
+declare -A DEVICE_TIER=(
+    ["EFG"]="enterprise"
+    ["UXG-Enterprise"]="enterprise"
+    ["UDM-Pro-Max"]="pro"
+    ["UDMPRO-Max"]="pro"
+    ["UDM-SE"]="pro"
+    ["UDMSE"]="pro"
+    ["UDM-Pro"]="pro"
+    ["UDMPRO"]="pro"
+    ["UDW"]="pro"
+    ["UCG-Max"]="pro"
+    ["UCG-Ultra"]="pro"
+    ["UCG-Fiber"]="pro"
+    ["UXG-Max"]="pro"
+    ["UXG-Pro"]="pro"
+    ["UXG-Fiber"]="pro"
+    ["UDM"]="consumer"
+    ["UDR"]="consumer"
+    ["UDR7"]="consumer"
+    ["UX7"]="consumer"
+    ["UX"]="unsupported"
+    ["UXG-Lite"]="unsupported"
+)
 
 detect_device_model() {
     local model=""
 
-    # Method 1: ubnt-device-info (most reliable)
+    # Method 1: ubnt-device-info (most reliable on UniFi OS 3+)
     if command -v ubnt-device-info >/dev/null 2>&1; then
         model=$(ubnt-device-info model 2>/dev/null)
     fi
 
-    # Method 2: /etc/unifi-os/unifi_version
-    if [ -z "$model" ] && [ -f /etc/unifi-os/unifi_version ]; then
-        model=$(grep -i "model" /etc/unifi-os/unifi_version 2>/dev/null | cut -d'=' -f2)
+    # Method 2: /proc/ubnthal/system.info (available on most UniFi OS devices)
+    if [ -z "$model" ] && [ -f /proc/ubnthal/system.info ]; then
+        model=$(grep -i "shortname" /proc/ubnthal/system.info 2>/dev/null | cut -d'=' -f2 | tr -d ' ')
     fi
 
-    # Method 3: /sys/firmware/devicetree/base/model
+    # Method 3: /etc/unifi-os/unifi_version
+    if [ -z "$model" ] && [ -f /etc/unifi-os/unifi_version ]; then
+        model=$(grep -i "model" /etc/unifi-os/unifi_version 2>/dev/null | cut -d'=' -f2 | tr -d ' ')
+    fi
+
+    # Method 4: /sys/firmware/devicetree/base/model
     if [ -z "$model" ] && [ -f /sys/firmware/devicetree/base/model ]; then
         model=$(cat /sys/firmware/devicetree/base/model 2>/dev/null | tr -d '\0')
     fi
 
-    # Method 4: Check dmesg for device identifiers
+    # Method 5: Check dmesg for device identifiers (last resort)
     if [ -z "$model" ]; then
-        for pattern in "UDM-SE" "UDM-Pro" "UDMPRO" "UDR" "UCG"; do
-            if dmesg 2>/dev/null | grep -qi "$pattern"; then
-                case "$pattern" in
-                    "UDM-SE") model="UniFi Dream Machine SE" ;;
-                    "UDM-Pro"|"UDMPRO") model="UniFi Dream Machine Pro" ;;
-                    "UDR") model="UniFi Dream Router" ;;
-                    "UCG") model="UniFi Cloud Gateway" ;;
-                esac
+        for pattern in "EFG" "UXG-Enterprise" "UDM-Pro-Max" "UDMPRO-Max" "UDM-SE" "UDMSE" "UDM-Pro" "UDMPRO" "UDW" "UCG-Max" "UCG-Ultra" "UCG-Fiber" "UXG-Max" "UXG-Pro" "UXG-Fiber" "UDR7" "UDR" "UDM" "UX7" "UXG-Lite" "UX"; do
+            if dmesg 2>/dev/null | grep -qi "\b${pattern}\b"; then
+                model="$pattern"
                 break
             fi
         done
@@ -56,21 +128,68 @@ detect_device_model() {
     echo "$model"
 }
 
+# Normalize model name to a known key
+# Handles variations like "UniFi Dream Machine SE" -> "UDM-SE"
+normalize_model() {
+    local model="$1"
+
+    # If it already matches a known key, return it
+    if [ -n "${DEVICE_MAXELEM[$model]+x}" ]; then
+        echo "$model"
+        return
+    fi
+
+    # Try matching against known keys (case-insensitive partial match)
+    for key in "${!DEVICE_MAXELEM[@]}"; do
+        # Check if model contains the key or key contains the model
+        if [[ "${model^^}" == *"${key^^}"* ]]; then
+            echo "$key"
+            return
+        fi
+    done
+
+    # Try common long-name to short-name mappings
+    case "$model" in
+        *"Dream Machine SE"*|*"Dream Machine Special"*)   echo "UDM-SE" ;;
+        *"Dream Machine Pro Max"*)                         echo "UDM-Pro-Max" ;;
+        *"Dream Machine Pro"*)                             echo "UDM-Pro" ;;
+        *"Dream Machine"*)                                 echo "UDM" ;;
+        *"Dream Router 7"*|*"Dream Router7"*)              echo "UDR7" ;;
+        *"Dream Router"*)                                  echo "UDR" ;;
+        *"Dream Wall"*)                                    echo "UDW" ;;
+        *"Cloud Gateway Max"*)                             echo "UCG-Max" ;;
+        *"Cloud Gateway Ultra"*)                           echo "UCG-Ultra" ;;
+        *"Cloud Gateway Fiber"*)                           echo "UCG-Fiber" ;;
+        *"Express 7"*|*"Express7"*)                        echo "UX7" ;;
+        *"Express"*)                                       echo "UX" ;;
+        *"Enterprise Fortress"*)                           echo "EFG" ;;
+        *)                                                 echo "$model" ;;
+    esac
+}
+
 get_safe_maxelem() {
     local model="$1"
-    local maxelem="${DEVICE_MAXELEM[$model]}"
+    local normalized
+    normalized=$(normalize_model "$model")
 
-    if [ -z "$maxelem" ]; then
-        # Try partial matching for variations
-        for key in "${!DEVICE_MAXELEM[@]}"; do
-            if [[ "$model" == *"$key"* ]] || [[ "$key" == *"$model"* ]]; then
-                maxelem="${DEVICE_MAXELEM[$key]}"
-                break
-            fi
-        done
+    local maxelem="${DEVICE_MAXELEM[$normalized]}"
+
+    # Check memory optimized mode
+    if [ "${MEMORY_OPTIMIZED:-false}" = "true" ]; then
+        local mem_limit="${MEMORY_OPTIMIZED_LIMITS[$normalized]}"
+        if [ -n "$mem_limit" ]; then
+            maxelem="$mem_limit"
+        fi
     fi
 
     echo "${maxelem:-$DEFAULT_MAXELEM}"
+}
+
+get_device_tier() {
+    local model="$1"
+    local normalized
+    normalized=$(normalize_model "$model")
+    echo "${DEVICE_TIER[$normalized]:-unknown}"
 }
 
 get_total_memory_mb() {
@@ -83,25 +202,149 @@ get_total_memory_mb() {
     fi
 }
 
+# Resolve the final maxelem value considering overrides and device detection
+resolve_maxelem() {
+    local model="$1"
+    local normalized
+    normalized=$(normalize_model "$model")
+    local recommended
+    recommended=$(get_safe_maxelem "$model")
+    local tier
+    tier=$(get_device_tier "$model")
+
+    # Check for unsupported device
+    if [ "$tier" = "unsupported" ]; then
+        echo "ERROR" "0" "$recommended" "$normalized"
+        return
+    fi
+
+    # MAXELEM_OVERRIDE takes precedence
+    if [ -n "${MAXELEM_OVERRIDE:-}" ]; then
+        if [ "$MAXELEM_OVERRIDE" -gt "$recommended" ] 2>/dev/null; then
+            echo "OVERRIDE_HIGH" "$MAXELEM_OVERRIDE" "$recommended" "$normalized"
+        else
+            echo "OVERRIDE" "$MAXELEM_OVERRIDE" "$recommended" "$normalized"
+        fi
+        return
+    fi
+
+    echo "AUTO" "$recommended" "$recommended" "$normalized"
+}
+
+# Print startup log messages (called by setup.sh or standalone)
+print_startup_info() {
+    local model="$1"
+    local normalized
+    normalized=$(normalize_model "$model")
+    local tier
+    tier=$(get_device_tier "$model")
+    local recommended
+    recommended=$(get_safe_maxelem "$model")
+    local mem_optimized="${MEMORY_OPTIMIZED:-false}"
+
+    # Resolve final value
+    local result
+    result=$(resolve_maxelem "$model")
+    local status final_value rec_value norm_model
+    read -r status final_value rec_value norm_model <<< "$result"
+
+    case "$status" in
+        ERROR)
+            echo "[ERROR] Detected device model: ${norm_model}"
+            echo "[ERROR] This device does not support firewall groups/ipsets"
+            echo "[ERROR] crowdsec-unifi-bouncer cannot run on this device"
+            return 1
+            ;;
+        OVERRIDE_HIGH)
+            echo "[INFO] Detected device model: ${norm_model:-Unknown} (${tier} tier)"
+            echo "[INFO] Recommended ipset limit: $rec_value"
+            echo "[WARNING] MAXELEM_OVERRIDE=$final_value exceeds recommended limit of $rec_value for ${norm_model:-Unknown}. This may cause instability."
+            echo "[INFO] Memory optimized mode: $mem_optimized"
+            echo "[INFO] Using ipset maxelem: $final_value (manual override)"
+            ;;
+        OVERRIDE)
+            echo "[INFO] Detected device model: ${norm_model:-Unknown} (${tier} tier)"
+            echo "[INFO] Recommended ipset limit: $rec_value"
+            echo "[INFO] Memory optimized mode: $mem_optimized"
+            echo "[INFO] Using ipset maxelem: $final_value (manual override)"
+            ;;
+        AUTO)
+            if [ -z "$model" ]; then
+                echo "[WARNING] Could not detect device model, using conservative limit of $DEFAULT_MAXELEM"
+                echo "[INFO] Set MAXELEM_OVERRIDE to specify a higher limit if needed"
+            else
+                echo "[INFO] Detected device model: ${norm_model} (${tier} tier)"
+                echo "[INFO] Recommended ipset limit: $rec_value"
+                echo "[INFO] Memory optimized mode: $mem_optimized"
+            fi
+            echo "[INFO] Using ipset maxelem: $final_value"
+            ;;
+    esac
+}
+
 # Main execution when run directly (not sourced)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     DETECTED_MODEL=$(detect_device_model)
-    SAFE_MAXELEM=$(get_safe_maxelem "$DETECTED_MODEL")
+    DETECTED_NORMALIZED=$(normalize_model "$DETECTED_MODEL")
     TOTAL_MEM=$(get_total_memory_mb)
 
-    echo "Device: ${DETECTED_MODEL:-Unknown}"
-    echo "RAM: ${TOTAL_MEM}MB"
-    echo "Default maxelem: $SAFE_MAXELEM"
-    echo "Recommended sidecar max_decisions: $((SAFE_MAXELEM - 2000))"
+    echo "=== CrowdSec UniFi Bouncer - Device Detection ==="
+    echo ""
+    echo "Raw model string: ${DETECTED_MODEL:-<not detected>}"
+    echo "Normalized model: ${DETECTED_NORMALIZED:-Unknown}"
+    echo "Device tier:      $(get_device_tier "$DETECTED_MODEL")"
+    echo "RAM:              ${TOTAL_MEM}MB"
+    echo ""
 
-    if [ -n "$MAXELEM" ]; then
-        echo "Configured maxelem: $MAXELEM"
+    # Show what would happen at startup
+    echo "--- Startup Output ---"
+    print_startup_info "$DETECTED_MODEL"
+    echo ""
+
+    SAFE_MAXELEM=$(get_safe_maxelem "$DETECTED_MODEL")
+    echo "--- Configuration ---"
+    echo "Recommended maxelem:      $SAFE_MAXELEM"
+    echo "Recommended max_decisions: $((SAFE_MAXELEM > 2000 ? SAFE_MAXELEM - 2000 : 0))"
+
+    if [ -n "${MAXELEM_OVERRIDE:-}" ]; then
+        echo "MAXELEM_OVERRIDE:         $MAXELEM_OVERRIDE"
     fi
+    if [ "${MEMORY_OPTIMIZED:-false}" = "true" ]; then
+        echo "MEMORY_OPTIMIZED:         true"
+    fi
+
+    echo ""
+    echo "--- All Known Devices ---"
+    printf "%-20s %-12s %-10s %-10s\n" "Model" "Tier" "Default" "Mem Opt"
+    printf "%-20s %-12s %-10s %-10s\n" "-----" "----" "-------" "-------"
+    for key in $(echo "${!DEVICE_MAXELEM[@]}" | tr ' ' '\n' | sort); do
+        local_tier="${DEVICE_TIER[$key]:-unknown}"
+        local_limit="${DEVICE_MAXELEM[$key]}"
+        local_mem="${MEMORY_OPTIMIZED_LIMITS[$key]:-—}"
+        printf "%-20s %-12s %-10s %-10s\n" "$key" "$local_tier" "$local_limit" "$local_mem"
+    done
 fi
 
 # Export variables when sourced
 DETECTED_MODEL=$(detect_device_model)
+DETECTED_NORMALIZED=$(normalize_model "$DETECTED_MODEL")
 SAFE_MAXELEM=$(get_safe_maxelem "$DETECTED_MODEL")
-# Recommended sidecar max_decisions: leave 2000 entries headroom for manual bans
-RECOMMENDED_SIDECAR_CAP=$((SAFE_MAXELEM - 2000))
-export RECOMMENDED_SIDECAR_CAP
+DEVICE_TIER_NAME=$(get_device_tier "$DETECTED_MODEL")
+
+# Resolve final maxelem (considers MAXELEM_OVERRIDE and MEMORY_OPTIMIZED)
+_resolve_result=$(resolve_maxelem "$DETECTED_MODEL")
+read -r _resolve_status FINAL_MAXELEM _resolve_rec _resolve_norm <<< "$_resolve_result"
+
+# For backward compatibility: if MAXELEM_OVERRIDE is set, use it; otherwise use auto-detected
+if [ "$_resolve_status" = "ERROR" ]; then
+    UNSUPPORTED_DEVICE=true
+    FINAL_MAXELEM=0
+else
+    UNSUPPORTED_DEVICE=false
+fi
+
+# Legacy variable name compatibility
+RECOMMENDED_SIDECAR_CAP=$((FINAL_MAXELEM > 2000 ? FINAL_MAXELEM - 2000 : 0))
+
+export DETECTED_MODEL DETECTED_NORMALIZED SAFE_MAXELEM DEVICE_TIER_NAME
+export FINAL_MAXELEM UNSUPPORTED_DEVICE RECOMMENDED_SIDECAR_CAP

--- a/setup.sh
+++ b/setup.sh
@@ -16,12 +16,31 @@ elif [ -f "$BOUNCER_DIR/detect-device.sh" ]; then
     source "$BOUNCER_DIR/detect-device.sh"
 fi
 
-# Maxelem selection: environment override -> device default
-if [ -z "$MAXELEM" ]; then
-    MAXELEM="${SAFE_MAXELEM:-20000}"
+# Check for unsupported device
+if [ "${UNSUPPORTED_DEVICE:-false}" = "true" ]; then
+    echo "[ERROR] Detected device model: ${DETECTED_NORMALIZED:-Unknown}"
+    echo "[ERROR] This device does not support firewall groups/ipsets"
+    echo "[ERROR] crowdsec-unifi-bouncer cannot run on this device"
+    exit 1
 fi
 
-echo "Device: ${DETECTED_MODEL:-Unknown}"
+# Print startup detection info
+if type print_startup_info >/dev/null 2>&1; then
+    print_startup_info "$DETECTED_MODEL"
+fi
+
+# Maxelem selection: FINAL_MAXELEM from detect-device.sh handles override logic
+# Fallback chain: MAXELEM env -> FINAL_MAXELEM -> SAFE_MAXELEM -> 10000
+if [ -n "${MAXELEM:-}" ]; then
+    # Legacy MAXELEM env var support (deprecated in favor of MAXELEM_OVERRIDE)
+    echo "[INFO] Using legacy MAXELEM=$MAXELEM (consider switching to MAXELEM_OVERRIDE)"
+elif [ -n "${FINAL_MAXELEM:-}" ] && [ "$FINAL_MAXELEM" -gt 0 ] 2>/dev/null; then
+    MAXELEM="$FINAL_MAXELEM"
+else
+    MAXELEM="${SAFE_MAXELEM:-10000}"
+fi
+
+echo "Device: ${DETECTED_NORMALIZED:-Unknown}"
 echo "Maxelem: $MAXELEM"
 
 # Detect sidecar configuration


### PR DESCRIPTION
## Summary

- Rewrites `detect-device.sh` with full device capacity matrix from [Ubiquiti CyberSecure IPS specs](https://help.ui.com/hc/en-us/articles/25930305913751)
- Adds all known UniFi gateway models across enterprise (80K), pro (50K), and consumer (15K) tiers
- Adds `MEMORY_OPTIMIZED=true` mode for devices running BGP/ad-blocking/content filtering (30K reduced limits)
- Adds `MAXELEM_OVERRIDE` env var with safety warnings when exceeding recommended limits
- Detects unsupported devices (UX, UXG-Lite) and exits gracefully with clear error messages
- Unknown devices fall back to conservative 10,000 limit with guidance to set MAXELEM_OVERRIDE
- Updates `setup.sh` to use new detection variables and block startup on unsupported devices
- Updates README with full device compatibility matrix, environment variable docs, and usage scenarios

## Test plan

- [ ] Verify `bash -n detect-device.sh` passes (syntax check — done)
- [ ] Test on UDM SE: confirm detection returns "UDM-SE" with 50,000 limit
- [ ] Test on UDR: confirm detection returns "UDR" with 15,000 limit
- [ ] Test `MAXELEM_OVERRIDE=70000` logs warning about exceeding recommended limit
- [ ] Test `MEMORY_OPTIMIZED=true` reduces pro-tier limits to 30,000
- [ ] Test with no detection methods available: confirm 10,000 fallback
- [ ] Verify backward compatibility: existing `MAXELEM` env var still works (with deprecation notice)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)