### PR TITLE
fix: memory guardrail auto-restart + PATH hardening for cron/systemd

### DIFF
--- a/ensure-rules.sh
+++ b/ensure-rules.sh
@@ -5,10 +5,13 @@
 # Add to crontab:
 #   */5 * * * * /data/crowdsec-bouncer/ensure-rules.sh
 
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+
 IPSET_NAME="crowdsec-blacklists"
 BOUNCER_DIR="/data/crowdsec-bouncer"
 LOGFILE="$BOUNCER_DIR/log/memory.log"
 METRICS_SCRIPT="$BOUNCER_DIR/metrics.sh"
+GUARDRAIL_FLAG="$BOUNCER_DIR/.guardrail-triggered"
 
 # Detect sidecar mode for capacity recommendations
 SIDECAR_MODE=""
@@ -38,9 +41,34 @@ if [ -f "$LOGFILE" ] && [ "$(wc -l < "$LOGFILE")" -gt 1000 ]; then
 fi
 echo "$(date '+%F %T') entries=$IPSET_COUNT mem_avail=${MEM_AVAIL}kB bouncer=$BOUNCER_ACTIVE" >> "$LOGFILE"
 
+# --- Memory guardrail recovery ---
+# If the guardrail previously stopped the bouncer and memory has recovered
+# above threshold (with 20% hysteresis to prevent flapping), restart it.
+RECOVERY_HYSTERESIS_PCT=120  # require memory at 120% of threshold before restarting
+RECOVERY_THRESHOLD=$((MEM_THRESHOLD * RECOVERY_HYSTERESIS_PCT / 100))
+
+if [ -f "$GUARDRAIL_FLAG" ]; then
+    if [ "$BOUNCER_ACTIVE" = "active" ]; then
+        # Bouncer was restarted manually — clean up stale flag
+        rm -f "$GUARDRAIL_FLAG"
+        echo "$(date '+%F %T') GUARDRAIL: stale flag cleared — bouncer was restarted externally" >> "$LOGFILE"
+    elif [ "$MEM_AVAIL" -ge "$RECOVERY_THRESHOLD" ]; then
+        # Memory has recovered sufficiently — restart the bouncer
+        systemctl start crowdsec-firewall-bouncer
+        rm -f "$GUARDRAIL_FLAG"
+        echo "$(date '+%F %T') RECOVERY: restarted bouncer — mem_avail=${MEM_AVAIL}kB (threshold=${MEM_THRESHOLD}kB, recovery=${RECOVERY_THRESHOLD}kB)" >> "$LOGFILE"
+        logger -t crowdsec-bouncer "RECOVERY: restarted bouncer — mem_avail=${MEM_AVAIL}kB recovered above threshold"
+        # Re-read bouncer status for the rule-check section below
+        BOUNCER_ACTIVE="active"
+        # Record recovery event for Prometheus metrics
+        [ -x "$METRICS_SCRIPT" ] && "$METRICS_SCRIPT" --record-guardrail-recovery 2>/dev/null || true
+    fi
+fi
+
 # If memory is critical and bouncer is running, stop it (ipset entries stay — protection continues)
 if [ "$MEM_AVAIL" -lt "$MEM_THRESHOLD" ] && [ "$BOUNCER_ACTIVE" = "active" ] && [ "$IPSET_COUNT" -gt 0 ]; then
     systemctl stop crowdsec-firewall-bouncer
+    touch "$GUARDRAIL_FLAG"
     echo "$(date '+%F %T') GUARDRAIL: stopped bouncer at $IPSET_COUNT entries, mem_avail=${MEM_AVAIL}kB (threshold=${MEM_THRESHOLD}kB)" >> "$LOGFILE"
     logger -t crowdsec-bouncer "GUARDRAIL: stopped bouncer — mem_avail=${MEM_AVAIL}kB, entries=$IPSET_COUNT"
     # Record guardrail event for Prometheus metrics

--- a/ipset-capacity-monitor.sh
+++ b/ipset-capacity-monitor.sh
@@ -17,6 +17,8 @@
 #   CAPACITY_LOG      - Log file for capacity events (default: $BOUNCER_DIR/log/capacity.log)
 #   STATE_FILE        - Metrics state file (default: $BOUNCER_DIR/metrics-state)
 
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+
 set -euo pipefail
 
 # Configuration

--- a/log-rules.sh
+++ b/log-rules.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # CrowdSec Firewall Bouncer - iptables LOG Rule Deployment
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
 # Inserts LOG rules before DROP rules in UniFi WAN chains for CrowdSec visibility
 #
 # Without LOG rules, the bouncer blocks traffic but CrowdSec cannot detect

--- a/metrics.sh
+++ b/metrics.sh
@@ -12,6 +12,8 @@
 #   IPSET_NAME        - Name of the ipset (default: crowdsec-blacklists)
 #   STATE_FILE        - Persistent state file for counters (default: $BOUNCER_DIR/metrics-state)
 
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+
 set -euo pipefail
 
 # Configuration
@@ -27,6 +29,7 @@ init_state() {
         cat > "$STATE_FILE" << 'STATEOF'
 errors_total=0
 guardrail_triggered_total=0
+guardrail_recovered_total=0
 rules_restored_total=0
 decisions_dropped_total=0
 capacity_events_total=0
@@ -37,6 +40,9 @@ STATEOF
     # Ensure new fields exist in old state files (upgrade path)
     if ! grep -q "^decisions_dropped_total=" "$STATE_FILE" 2>/dev/null; then
         echo "decisions_dropped_total=0" >> "$STATE_FILE"
+    fi
+    if ! grep -q "^guardrail_recovered_total=" "$STATE_FILE" 2>/dev/null; then
+        echo "guardrail_recovered_total=0" >> "$STATE_FILE"
     fi
     if ! grep -q "^capacity_events_total=" "$STATE_FILE" 2>/dev/null; then
         echo "capacity_events_total=0" >> "$STATE_FILE"
@@ -155,6 +161,7 @@ collect_metrics() {
     init_state
     local errors_total
     local guardrail_triggered_total
+    local guardrail_recovered_total
     local rules_restored_total
     local decisions_dropped_total
     local capacity_events_total
@@ -162,6 +169,7 @@ collect_metrics() {
     local degraded
     errors_total=$(read_counter "errors_total")
     guardrail_triggered_total=$(read_counter "guardrail_triggered_total")
+    guardrail_recovered_total=$(read_counter "guardrail_recovered_total")
     rules_restored_total=$(read_counter "rules_restored_total")
     decisions_dropped_total=$(read_counter "decisions_dropped_total")
     capacity_events_total=$(read_counter "capacity_events_total")
@@ -227,6 +235,10 @@ crowdsec_unifi_bouncer_errors_total $errors_total
 # HELP crowdsec_unifi_bouncer_guardrail_triggered_total Number of times memory guardrail stopped the bouncer
 # TYPE crowdsec_unifi_bouncer_guardrail_triggered_total counter
 crowdsec_unifi_bouncer_guardrail_triggered_total $guardrail_triggered_total
+
+# HELP crowdsec_unifi_bouncer_guardrail_recovered_total Number of times the bouncer auto-restarted after memory recovery
+# TYPE crowdsec_unifi_bouncer_guardrail_recovered_total counter
+crowdsec_unifi_bouncer_guardrail_recovered_total $guardrail_recovered_total
 
 # HELP crowdsec_unifi_bouncer_rules_restored_total Number of times iptables rules were re-added after removal
 # TYPE crowdsec_unifi_bouncer_rules_restored_total counter
@@ -308,6 +320,11 @@ record_guardrail() {
     increment_counter "guardrail_triggered_total" >/dev/null
 }
 
+record_guardrail_recovery() {
+    init_state
+    increment_counter "guardrail_recovered_total" >/dev/null
+}
+
 record_rule_restored() {
     init_state
     increment_counter "rules_restored_total" >/dev/null
@@ -342,6 +359,9 @@ case "${1:-}" in
     --record-guardrail)
         record_guardrail
         ;;
+    --record-guardrail-recovery)
+        record_guardrail_recovery
+        ;;
     --record-rule-restored)
         record_rule_restored
         ;;
@@ -363,6 +383,7 @@ Usage:
 Recording helpers (for use by ensure-rules.sh and ipset-capacity-monitor.sh):
   $0 --record-error              Increment errors_total counter
   $0 --record-guardrail          Increment guardrail_triggered_total counter
+  $0 --record-guardrail-recovery  Increment guardrail_recovered_total counter
   $0 --record-rule-restored      Increment rules_restored_total counter
   $0 --record-dropped [N]        Record N decisions dropped due to capacity (default: 1)
   $0 --record-decisions-dropped [N]  Alias for --record-dropped

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,8 @@
 # Ensures ipset, iptables rules, and systemd service persist across firmware updates
 # Run as ExecStartPre in systemd service
 
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+
 set -e
 
 BOUNCER_DIR="/data/crowdsec-bouncer"


### PR DESCRIPTION
## Changes

### Memory guardrail auto-restart (fixes #54)
The memory guardrail in `ensure-rules.sh` correctly stops `crowdsec-firewall-bouncer` when memory is low, but had no mechanism to restart it once memory recovers. This left the WAN-facing gateway with zero active IP blocking indefinitely until manual intervention.

**Fix:** tracks guardrail state via a `.guardrail-triggered` flag file. On subsequent cron runs, if memory has recovered above threshold (with 20% hysteresis to prevent flapping), the bouncer is automatically restarted and the flag cleared. If the bouncer was restarted externally, the stale flag is cleaned up automatically.

### PATH hardening (addresses #53 addendum)
All shell scripts now set `export PATH="/usr/sbin:/usr/bin:/sbin:/bin:$PATH"` at the top. This prevents silent failures under cron and systemd, where `/usr/sbin` is not in the default PATH. Previously, `ipset` and `iptables` calls (which live at `/usr/sbin/`) would fail silently with \"command not found\" redirected to `/dev/null`, causing:
- Core self-healing rule restoration to never function under cron
- ipset capacity warnings to always log `entries=0` under cron
- Prometheus metrics to report zeroed values from the metrics service

## Files changed
- `ensure-rules.sh` — memory recovery logic + PATH
- `metrics.sh` — guardrail_recovered_total counter + PATH
- `ipset-capacity-monitor.sh` — PATH
- `log-rules.sh` — PATH
- `setup.sh` — PATH

Closes #54. References the PATH finding from issue #53.