### PR TITLE
Fix #54 memory guardrail never restarts bouncer; fix #53 PATH resolution under cron/systemd

### DIFF
--- a/crowdsec-unifi-metrics.service
+++ b/crowdsec-unifi-metrics.service
@@ -7,6 +7,10 @@ RequiresMountsFor=/data/crowdsec-bouncer
 
 [Service]
 Type=simple
+# systemd gives services a minimal PATH without /usr/sbin, where ipset/iptables
+# live on UniFi OS. Without this, metrics.sh reports zeroed/empty values for
+# ipset and rule state under systemd while working in an interactive shell. (#53)
+Environment=PATH=/usr/sbin:/usr/bin:/sbin:/bin
 Environment=METRICS_PORT=9101
 Environment=BOUNCER_DIR=/data/crowdsec-bouncer
 Environment=IPSET_NAME=crowdsec-blacklists

--- a/ipset-capacity-monitor.sh
+++ b/ipset-capacity-monitor.sh
@@ -19,6 +19,12 @@
 
 set -euo pipefail
 
+# --- PATH hardening -----------------------------------------------------------
+# cron/systemd provide a minimal PATH without /usr/sbin, where ipset/iptables
+# live on UniFi OS. Without this, those calls silently fail under unattended
+# execution while working fine in an interactive shell. See issue #53.
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+
 # Configuration
 BOUNCER_DIR="${BOUNCER_DIR:-/data/crowdsec-bouncer}"
 IPSET_NAME="${IPSET_NAME:-crowdsec-blacklists}"

--- a/metrics.sh
+++ b/metrics.sh
@@ -14,6 +14,12 @@
 
 set -euo pipefail
 
+# --- PATH hardening -----------------------------------------------------------
+# cron/systemd provide a minimal PATH without /usr/sbin, where ipset/iptables
+# live on UniFi OS. Without this, those calls silently fail under unattended
+# execution while working fine in an interactive shell. See issue #53.
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+
 # Configuration
 METRICS_PORT="${METRICS_PORT:-9101}"
 BOUNCER_DIR="${BOUNCER_DIR:-/data/crowdsec-bouncer}"
@@ -27,6 +33,7 @@ init_state() {
         cat > "$STATE_FILE" << 'STATEOF'
 errors_total=0
 guardrail_triggered_total=0
+guardrail_recovered_total=0
 rules_restored_total=0
 decisions_dropped_total=0
 capacity_events_total=0
@@ -37,6 +44,9 @@ STATEOF
     # Ensure new fields exist in old state files (upgrade path)
     if ! grep -q "^decisions_dropped_total=" "$STATE_FILE" 2>/dev/null; then
         echo "decisions_dropped_total=0" >> "$STATE_FILE"
+    fi
+    if ! grep -q "^guardrail_recovered_total=" "$STATE_FILE" 2>/dev/null; then
+        echo "guardrail_recovered_total=0" >> "$STATE_FILE"
     fi
     if ! grep -q "^capacity_events_total=" "$STATE_FILE" 2>/dev/null; then
         echo "capacity_events_total=0" >> "$STATE_FILE"
@@ -155,6 +165,7 @@ collect_metrics() {
     init_state
     local errors_total
     local guardrail_triggered_total
+    local guardrail_recovered_total
     local rules_restored_total
     local decisions_dropped_total
     local capacity_events_total
@@ -162,6 +173,7 @@ collect_metrics() {
     local degraded
     errors_total=$(read_counter "errors_total")
     guardrail_triggered_total=$(read_counter "guardrail_triggered_total")
+    guardrail_recovered_total=$(read_counter "guardrail_recovered_total")
     rules_restored_total=$(read_counter "rules_restored_total")
     decisions_dropped_total=$(read_counter "decisions_dropped_total")
     capacity_events_total=$(read_counter "capacity_events_total")
@@ -227,6 +239,9 @@ crowdsec_unifi_bouncer_errors_total $errors_total
 # HELP crowdsec_unifi_bouncer_guardrail_triggered_total Number of times memory guardrail stopped the bouncer
 # TYPE crowdsec_unifi_bouncer_guardrail_triggered_total counter
 crowdsec_unifi_bouncer_guardrail_triggered_total $guardrail_triggered_total
+# HELP crowdsec_unifi_bouncer_guardrail_recovered_total Number of times the bouncer was auto-restarted after memory recovered
+# TYPE crowdsec_unifi_bouncer_guardrail_recovered_total counter
+crowdsec_unifi_bouncer_guardrail_recovered_total $guardrail_recovered_total
 
 # HELP crowdsec_unifi_bouncer_rules_restored_total Number of times iptables rules were re-added after removal
 # TYPE crowdsec_unifi_bouncer_rules_restored_total counter
@@ -308,6 +323,11 @@ record_guardrail() {
     increment_counter "guardrail_triggered_total" >/dev/null
 }
 
+record_guardrail_recovery() {
+    init_state
+    increment_counter "guardrail_recovered_total" >/dev/null
+}
+
 record_rule_restored() {
     init_state
     increment_counter "rules_restored_total" >/dev/null
@@ -342,6 +362,9 @@ case "${1:-}" in
     --record-guardrail)
         record_guardrail
         ;;
+    --record-guardrail-recovery)
+        record_guardrail_recovery
+        ;;
     --record-rule-restored)
         record_rule_restored
         ;;
@@ -363,6 +386,7 @@ Usage:
 Recording helpers (for use by ensure-rules.sh and ipset-capacity-monitor.sh):
   $0 --record-error              Increment errors_total counter
   $0 --record-guardrail          Increment guardrail_triggered_total counter
+  $0 --record-guardrail-recovery Increment guardrail_recovered_total counter
   $0 --record-rule-restored      Increment rules_restored_total counter
   $0 --record-dropped [N]        Record N decisions dropped due to capacity (default: 1)
   $0 --record-decisions-dropped [N]  Alias for --record-dropped


### PR DESCRIPTION
Fixes two independent bugs reported this weekend, both in the cron/systemd-run helper scripts.

## #54 — CRITICAL: memory guardrail stopped the bouncer but never restarted it

`ensure-rules.sh` stops `crowdsec-firewall-bouncer` when `MemAvailable` drops below `MEM_THRESHOLD`, then `exit 0`s. There was no path anywhere that restarts it once memory recovers, so the guardrail was a one-way trip — the WAN-facing bouncer stayed down with zero active blocking until a human noticed.

**Fix:** on a guardrail stop, drop a `.guardrail-stopped` marker (holding a healthy-run counter). On later runs, once `MemAvailable` climbs back above `MEM_THRESHOLD + MEM_RECOVERY_MARGIN` (default +100 MB, hysteresis) for `RECOVERY_CONFIRM_RUNS` consecutive checks (default 2, ~10 min), restart the bouncer, clear the marker, and re-verify rules. The marker is the authorization key: a **manual** operator stop leaves no marker, so an operator's intentional stop is never overridden. New `guardrail_recovered_total` Prometheus counter exposes recoveries.

Validated with a 9-scenario simulation (mocked `ipset`/`iptables`/`systemctl`) covering stop -> wait -> dip-and-reset -> confirm -> restart, plus the operator-restart and manual-stop edge cases. Timing reproduces the reporter's log (stop 12:55, recovered by 13:00, auto-restart ~13:10-13:15).

## #53 (item 1) — PATH bug: `ipset`/`iptables` unresolved under cron/systemd

None of `ensure-rules.sh`, `ipset-capacity-monitor.sh`, `metrics.sh` set an explicit `PATH`, and every `ipset`/`iptables` call is bare with stderr suppressed. On devices where these live in `/usr/sbin` (e.g. UCG-Fiber), the minimal cron/systemd PATH means the self-healing rule restoration and capacity monitoring silently no-op in exactly the unattended context they exist for.

**Fix:** `export PATH=/usr/sbin:/usr/bin:/sbin:/bin:$PATH` at the top of all three scripts, and `Environment=PATH=...` in `crowdsec-unifi-metrics.service`.

All three scripts pass `shellcheck -S warning` clean.

The `#53` sidecar eviction items (`evict`/`cap` mode) are deliberately **not** in this PR — they're separate design work in the Go sidecar and will be tracked/addressed separately.
