### PR TITLE
fix(sidecar): tracker cap/evict bugs, add tests, v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Supports all WAN chains: LOCAL, LAN, IN, DMZ, GUEST, VPN, WAN
   - Standalone usage: `--status`, `--remove`, `--quiet` flags
 
+## [2.5.0] - 2026-07-21
+
+### Fixed
+- **Stream tracker cap mode silently drops incrementals after full sync** — when a full sync returned more CAPI decisions than `maxDecisions` (e.g., UDM Pro with 20k active vs 15k max), the incremental counter started already over the cap, silently dropping all subsequent incremental decisions. The cap now only applies to INCREMENTAL CAPI additions after the full sync baseline; baseline decisions are tracked separately in `fullSyncSet` and always passed through authoritatively. (Closes #58)
+- **Stream tracker evict mode causes mass eviction on restart** — after sidecar restart, `SetCapFromFullSync` repopulated the eviction-ordered `tracked` slice with all baseline CAPI decisions, making evictions potentially replace baseline (full-sync) decisions. The `tracked` slice now only holds incremental decisions; eviction can never touch the authoritative baseline. (Closes #57)
+
+### Added
+- `BaseCount` metric to expose the full-sync baseline CAPI decision count separately from incremental `CAPICount`
+- 4 new regression tests for #57 and #58 behaviors
+
 ## [2.4.0] - 2026-03-13
 
 ### Added
@@ -71,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cron-based iptables rule recovery
 - ipset capacity monitoring with Prometheus metrics
 
+[2.5.0]: https://github.com/wolffcatskyy/crowdsec-unifi-bouncer/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/wolffcatskyy/crowdsec-unifi-bouncer/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/wolffcatskyy/crowdsec-unifi-bouncer/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/wolffcatskyy/crowdsec-unifi-bouncer/compare/v2.1.0...v2.2.0

--- a/sidecar/internal/tracker/tracker.go
+++ b/sidecar/internal/tracker/tracker.go
@@ -56,21 +56,36 @@ type trackedDecision struct {
 
 // StreamTracker tracks cumulative CAPI decision counts between full syncs
 // and enforces the configured cap on incremental stream updates.
+// Two sets of decisions are tracked separately:
+//   - fullSyncSet: CAPI decisions from the authoritative full sync (always passed through)
+//   - trackedSet: INCREMENTAL CAPI decisions added since the last full sync
+//
+// The cap only applies to incremental additions. This fixes the bug where a full sync
+// returning more CAPI decisions than maxDecisions (e.g., UDM Pro with 20k active vs 15k max)
+// would make capiCount start over the cap, silently dropping all subsequent incrementals.
+// Evictions also only ever replace incremental decisions, never baseline ones.
 type StreamTracker struct {
 	mu           sync.Mutex
 	maxDecisions int
 	mode         EvictionMode
 	logger       *slog.Logger
 
-	// Cumulative count of CAPI decisions passed since last full sync.
+	// Cumulative count of INCREMENTAL CAPI decisions added since last full sync.
+	// Full sync baseline decisions are NOT counted here — the cap only applies to
+	// incremental additions (fixes #58).
 	capiCount int
 
-	// Ordered list of tracked CAPI decisions (oldest first) for eviction mode.
-	// Only populated when mode == ModeEvict.
+	// Ordered list of tracked INCREMENTAL CAPI decisions (oldest first) for eviction mode.
+	// Only populated when mode == ModeEvict. Never includes full-sync baseline decisions
+	// so eviction can never remove a baseline decision (fixes #57).
 	tracked []trackedDecision
 
-	// Set of currently tracked CAPI decision values for deduplication.
+	// Set of all currently tracked CAPI decision values for deduplication (baseline + incremental).
 	trackedSet map[string]struct{}
+
+	// Set of CAPI decision values from the authoritative full sync.
+	// These are not counted in capiCount and are never subject to eviction.
+	fullSyncSet map[string]struct{}
 
 	// Metrics (atomic for lock-free reads from metrics endpoint)
 	decisionsPassed atomic.Int64
@@ -87,7 +102,8 @@ type Metrics struct {
 	Evictions        int64
 	FullSyncs        int64
 	LastFullSync     int64
-	CAPICount        int
+	CAPICount        int // INCREMENTAL CAPI count (additions since last full sync)
+	BaseCount        int // Full-sync baseline CAPI decisions (authoritative set)
 	MaxDecisions     int
 	EvictionMode     string
 }
@@ -102,6 +118,7 @@ func New(maxDecisions int, mode EvictionMode, logger *slog.Logger) *StreamTracke
 		mode:         mode,
 		logger:       logger,
 		trackedSet:   make(map[string]struct{}),
+		fullSyncSet:  make(map[string]struct{}),
 	}
 }
 
@@ -113,6 +130,7 @@ func (t *StreamTracker) Reset() {
 	t.capiCount = 0
 	t.tracked = nil
 	t.trackedSet = make(map[string]struct{})
+	t.fullSyncSet = make(map[string]struct{})
 	t.fullSyncs.Add(1)
 	t.lastFullSync.Store(time.Now().Unix())
 
@@ -202,15 +220,24 @@ func (t *StreamTracker) addTracked(d lapi.Decision) {
 }
 
 // removeTracked removes a CAPI decision from tracking (called on deletion).
+// If the decision was part of the full-sync baseline, only the dedup set is updated
+// (capiCount is not decremented since baseline decisions are not counted).
+// If the decision was an incremental addition, capiCount is decremented.
 func (t *StreamTracker) removeTracked(value string) {
 	if _, exists := t.trackedSet[value]; !exists {
 		return
 	}
 
 	delete(t.trackedSet, value)
-	t.capiCount--
-	if t.capiCount < 0 {
-		t.capiCount = 0
+
+	// Only decrement capiCount if this was an incremental, not a baseline decision
+	if _, isBaseline := t.fullSyncSet[value]; isBaseline {
+		delete(t.fullSyncSet, value)
+	} else {
+		t.capiCount--
+		if t.capiCount < 0 {
+			t.capiCount = 0
+		}
 	}
 
 	if t.mode == ModeEvict {
@@ -243,27 +270,34 @@ func (t *StreamTracker) evictOldest() bool {
 	return true
 }
 
-// SetCapFromFullSync updates the CAPI count to reflect the number of CAPI decisions
-// that were included in a full sync response. This ensures the tracker knows how much
-// capacity remains for incremental decisions.
+// SetCapFromFullSync records the CAPI decisions from a full sync response as the
+// authoritative baseline. These baseline decisions are always passed through and are
+// NOT counted against the cap — the cap only applies to INCREMENTAL CAPI decisions
+// added after the full sync. This ensures that when a full sync returns more CAPI
+// decisions than maxDecisions (e.g., UDM Pro with 20k active vs 15k max), subsequent
+// incremental decisions are not silently dropped (fixes #58).
 func (t *StreamTracker) SetCapFromFullSync(capiDecisions []lapi.Decision) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	// Reset incremental tracking state
 	t.capiCount = 0
 	t.tracked = nil
 	t.trackedSet = make(map[string]struct{})
+	t.fullSyncSet = make(map[string]struct{})
 
+	// Populate the baseline set from the full sync response
+	// These are NOT counted in capiCount — they're authoritative and always passed through
 	for _, d := range capiDecisions {
 		if !IsLocalOrigin(d.Origin) {
-			t.addTracked(d)
+			t.fullSyncSet[d.Value] = struct{}{}
+			t.trackedSet[d.Value] = struct{}{}
 		}
 	}
 
 	t.logger.Info("stream tracker initialized from full sync",
-		"capi_count", t.capiCount,
-		"max", t.maxDecisions,
-		"headroom", t.maxDecisions-t.capiCount,
+		"base_capi_count", len(t.fullSyncSet),
+		"max_incrementals", t.maxDecisions,
 	)
 }
 
@@ -271,6 +305,7 @@ func (t *StreamTracker) SetCapFromFullSync(capiDecisions []lapi.Decision) {
 func (t *StreamTracker) GetMetrics() Metrics {
 	t.mu.Lock()
 	capiCount := t.capiCount
+	baseCount := len(t.fullSyncSet)
 	t.mu.Unlock()
 
 	return Metrics{
@@ -280,6 +315,7 @@ func (t *StreamTracker) GetMetrics() Metrics {
 		FullSyncs:        t.fullSyncs.Load(),
 		LastFullSync:     t.lastFullSync.Load(),
 		CAPICount:        capiCount,
+		BaseCount:        baseCount,
 		MaxDecisions:     t.maxDecisions,
 		EvictionMode:     string(t.mode),
 	}

--- a/sidecar/internal/tracker/tracker_test.go
+++ b/sidecar/internal/tracker/tracker_test.go
@@ -212,26 +212,34 @@ func TestStreamTracker_SetCapFromFullSync(t *testing.T) {
 	tr.SetCapFromFullSync(decisions)
 
 	metrics := tr.GetMetrics()
-	if metrics.CAPICount != 3 {
-		t.Errorf("expected CAPICount=3, got %d", metrics.CAPICount)
+	// capiCount tracks INCREMENTAL additions only (starts at 0 after full sync)
+	if metrics.CAPICount != 0 {
+		t.Errorf("expected CAPICount=0 (incrementals), got %d", metrics.CAPICount)
+	}
+	if metrics.BaseCount != 3 {
+		t.Errorf("expected BaseCount=3 (full sync CAPI), got %d", metrics.BaseCount)
 	}
 
-	// Should have headroom for 2 more CAPI decisions
+	// Should have headroom for up to maxDecisions (5) incremental CAPI decisions
+	// All 3 incrementals should pass since capiCount=0 and max=5
 	stream := &lapi.DecisionStream{
 		New: []lapi.Decision{
 			{ID: 5, Origin: "CAPI", Value: "5.5.5.5", Scope: "ip"},
 			{ID: 6, Origin: "CAPI", Value: "6.6.6.6", Scope: "ip"},
-			{ID: 7, Origin: "CAPI", Value: "7.7.7.7", Scope: "ip"}, // should be dropped
+			{ID: 7, Origin: "CAPI", Value: "7.7.7.7", Scope: "ip"},
 		},
 	}
 	kept := tr.FilterStreamDecisions(stream)
-	if len(kept) != 2 {
-		t.Fatalf("expected 2 kept, got %d", len(kept))
+	if len(kept) != 3 {
+		t.Fatalf("expected 3 kept (cap only applies to incrementals), got %d", len(kept))
 	}
 
 	metrics = tr.GetMetrics()
-	if metrics.DecisionsDropped != 1 {
-		t.Errorf("expected 1 dropped, got %d", metrics.DecisionsDropped)
+	if metrics.DecisionsDropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", metrics.DecisionsDropped)
+	}
+	if metrics.CAPICount != 3 {
+		t.Errorf("expected CAPICount=3 (3 incrementals added), got %d", metrics.CAPICount)
 	}
 }
 
@@ -260,8 +268,8 @@ func TestStreamTracker_DuplicateDecisionsNotDoubleCounted(t *testing.T) {
 }
 
 func TestStreamTracker_IncrementalAccumulation(t *testing.T) {
-	// Simulates the real-world scenario from issue #39:
-	// Full sync sets 13000, then incremental adds trickle in one at a time
+	// Simulates the real-world scenario:
+	// Full sync sets 5 CAPI at cap, then incremental adds trickle in one at a time
 	tr := New(5, ModeCap, testLogger())
 
 	// Simulate full sync result being used to set cap
@@ -273,8 +281,22 @@ func TestStreamTracker_IncrementalAccumulation(t *testing.T) {
 	}
 	tr.SetCapFromFullSync(fullSyncDecisions)
 
-	// Now incremental decisions arrive one at a time — all should be capped
-	for i := 0; i < 10; i++ {
+	// capiCount starts at 0 after full sync — cap applies only to incrementals
+	// With max=5, the first 5 incremental decisions pass, then the rest are dropped
+	for i := 0; i < 5; i++ {
+		stream := &lapi.DecisionStream{
+			New: []lapi.Decision{
+				{ID: 100 + i, Origin: "CAPI", Value: makeIP(100 + i), Scope: "ip"},
+			},
+		}
+		kept := tr.FilterStreamDecisions(stream)
+		if len(kept) != 1 {
+			t.Errorf("incremental %d: expected 1 kept (under cap), got %d", i, len(kept))
+		}
+	}
+
+	// Now at cap — subsequent incrementals should be dropped
+	for i := 5; i < 10; i++ {
 		stream := &lapi.DecisionStream{
 			New: []lapi.Decision{
 				{ID: 100 + i, Origin: "CAPI", Value: makeIP(100 + i), Scope: "ip"},
@@ -287,8 +309,173 @@ func TestStreamTracker_IncrementalAccumulation(t *testing.T) {
 	}
 
 	metrics := tr.GetMetrics()
-	if metrics.DecisionsDropped != 10 {
-		t.Errorf("expected 10 dropped incrementals, got %d", metrics.DecisionsDropped)
+	if metrics.CAPICount != 5 {
+		t.Errorf("expected CAPICount=5 (incrementals), got %d", metrics.CAPICount)
+	}
+	if metrics.BaseCount != 5 {
+		t.Errorf("expected BaseCount=5 (baseline), got %d", metrics.BaseCount)
+	}
+	if metrics.DecisionsDropped != 5 {
+		t.Errorf("expected 5 dropped incrementals, got %d", metrics.DecisionsDropped)
+	}
+}
+
+func TestStreamTracker_FullSyncExceedsMaxDecisions(t *testing.T) {
+	// Bug #58 regression test: When full sync returns MORE CAPI decisions than
+	// maxDecisions (e.g., UDM Pro with 20k active vs 15k max), the tracker must
+	// NOT silently drop subsequent incremental decisions.
+	// capiCount starts at 0 after full sync — only incrementals are capped.
+	tr := New(3, ModeCap, testLogger())
+
+	// Full sync has 6 CAPI decisions (exceeding maxDecisions=3)
+	fullSyncDecisions := make([]lapi.Decision, 6)
+	for i := range fullSyncDecisions {
+		fullSyncDecisions[i] = lapi.Decision{
+			ID: i + 1, Origin: "CAPI", Value: makeIP(i + 1), Scope: "ip",
+		}
+	}
+	tr.SetCapFromFullSync(fullSyncDecisions)
+
+	// Verify baseline is tracked separately from incrementals
+	metrics := tr.GetMetrics()
+	if metrics.BaseCount != 6 {
+		t.Errorf("expected BaseCount=6 (full sync baseline), got %d", metrics.BaseCount)
+	}
+	if metrics.CAPICount != 0 {
+		t.Errorf("expected CAPICount=0 (no incrementals yet), got %d", metrics.CAPICount)
+	}
+	if metrics.DecisionsDropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", metrics.DecisionsDropped)
+	}
+
+	// Incremental decisions should still be addable up to maxDecisions=3
+	for i := 0; i < 3; i++ {
+		stream := &lapi.DecisionStream{
+			New: []lapi.Decision{
+				{ID: 100 + i, Origin: "CAPI", Value: makeIP(100 + i), Scope: "ip"},
+			},
+		}
+		kept := tr.FilterStreamDecisions(stream)
+		if len(kept) != 1 {
+			t.Errorf("incremental %d: expected 1 kept, got %d", i, len(kept))
+		}
+	}
+
+	// 4th incremental should be dropped (at cap)
+	stream := &lapi.DecisionStream{
+		New: []lapi.Decision{
+			{ID: 103, Origin: "CAPI", Value: makeIP(103), Scope: "ip"},
+		},
+	}
+	kept := tr.FilterStreamDecisions(stream)
+	if len(kept) != 0 {
+		t.Errorf("expected 0 kept (at incremental cap), got %d", len(kept))
+	}
+
+	metrics = tr.GetMetrics()
+	if metrics.CAPICount != 3 {
+		t.Errorf("expected CAPICount=3 (incrementals), got %d", metrics.CAPICount)
+	}
+	if metrics.BaseCount != 6 {
+		t.Errorf("expected BaseCount=6 (baseline unchanged), got %d", metrics.BaseCount)
+	}
+	if metrics.DecisionsDropped != 1 {
+		t.Errorf("expected 1 dropped, got %d", metrics.DecisionsDropped)
+	}
+
+	// Local decisions should still always pass regardless of cap
+	stream = &lapi.DecisionStream{
+		New: []lapi.Decision{
+			{ID: 200, Origin: "crowdsec", Value: "10.0.0.1", Scope: "ip"},
+		},
+	}
+	kept = tr.FilterStreamDecisions(stream)
+	if len(kept) != 1 {
+		t.Errorf("expected 1 kept (local passes even at cap), got %d", len(kept))
+	}
+}
+
+func TestStreamTracker_EvictModeBaselineProtected(t *testing.T) {
+	// Bug #57 regression test: After SetCapFromFullSync, eviction should only
+	// ever replace INCREMENTAL decisions, never baseline decisions from the
+	// authoritative full sync.
+	tr := New(3, ModeEvict, testLogger())
+
+	// Full sync with 3 baseline CAPI decisions
+	fullSyncDecisions := []lapi.Decision{
+		{ID: 1, Origin: "CAPI", Value: "10.0.0.1", Scope: "ip"},
+		{ID: 2, Origin: "CAPI", Value: "10.0.0.2", Scope: "ip"},
+		{ID: 3, Origin: "CAPI", Value: "10.0.0.3", Scope: "ip"},
+	}
+	tr.SetCapFromFullSync(fullSyncDecisions)
+
+	metrics := tr.GetMetrics()
+	if metrics.BaseCount != 3 {
+		t.Errorf("expected BaseCount=3, got %d", metrics.BaseCount)
+	}
+	if metrics.CAPICount != 0 {
+		t.Errorf("expected CAPICount=0 (no incrementals), got %d", metrics.CAPICount)
+	}
+
+	// Add 3 incremental CAPI decisions (fills incremental capacity)
+	for i := 0; i < 3; i++ {
+		stream := &lapi.DecisionStream{
+			New: []lapi.Decision{
+				{ID: 10 + i, Origin: "CAPI", Value: makeIP(10 + i), Scope: "ip"},
+			},
+		}
+		kept := tr.FilterStreamDecisions(stream)
+		if len(kept) != 1 {
+			t.Errorf("incremental %d: expected 1 kept, got %d", i, len(kept))
+		}
+	}
+
+	metrics = tr.GetMetrics()
+	if metrics.CAPICount != 3 {
+		t.Errorf("expected CAPICount=3, got %d", metrics.CAPICount)
+	}
+
+	// Now at cap — evict should replace an INCREMENTAL, not a baseline decision
+	stream := &lapi.DecisionStream{
+		New: []lapi.Decision{
+			{ID: 20, Origin: "CAPI", Value: "10.0.0.100", Scope: "ip"},
+		},
+	}
+	kept := tr.FilterStreamDecisions(stream)
+	if len(kept) != 1 {
+		t.Fatalf("expected 1 kept (evicted), got %d", len(kept))
+	}
+
+	metrics = tr.GetMetrics()
+	if metrics.Evictions != 1 {
+		t.Errorf("expected 1 eviction, got %d", metrics.Evictions)
+	}
+	// CAPICount should remain at 3 (evict replaces one)
+	if metrics.CAPICount != 3 {
+		t.Errorf("expected CAPICount=3 after eviction, got %d", metrics.CAPICount)
+	}
+	// BaseCount should still be 3 (baseline decisions are NEVER evicted)
+	if metrics.BaseCount != 3 {
+		t.Errorf("expected BaseCount=3 (baseline protected from eviction), got %d", metrics.BaseCount)
+	}
+
+	// Verify the baseline decisions are still tracked in the full sync set
+	tr.mu.Lock()
+	_, b1Exists := tr.fullSyncSet["10.0.0.1"]
+	_, b2Exists := tr.fullSyncSet["10.0.0.2"]
+	_, b3Exists := tr.fullSyncSet["10.0.0.3"]
+	tr.mu.Unlock()
+
+	if !b1Exists || !b2Exists || !b3Exists {
+		t.Errorf("baseline decisions were removed from fullSyncSet after eviction")
+	}
+
+	// And the new decision is in trackedSet
+	tr.mu.Lock()
+	_, newExists := tr.trackedSet["10.0.0.100"]
+	tr.mu.Unlock()
+	if !newExists {
+		t.Errorf("evicted decision not in trackedSet")
 	}
 }
 
@@ -387,6 +574,100 @@ func TestStreamTracker_DefaultEvictionMode(t *testing.T) {
 	metrics := tr.GetMetrics()
 	if metrics.EvictionMode != string(ModeCap) {
 		t.Errorf("expected default mode 'cap', got %q", metrics.EvictionMode)
+	}
+}
+
+func TestStreamTracker_IncrementalDeletionFreesCapacity(t *testing.T) {
+	// Verify that deleting an incremental CAPI decision frees a slot for a new one.
+	// This is the same mechanism as TestStreamTracker_DeletionFreesCapacity but
+	// explicitly testing the incremental path.
+	tr := New(2, ModeCap, testLogger())
+
+	// Add 2 incremental CAPI decisions
+	stream := &lapi.DecisionStream{
+		New: []lapi.Decision{
+			{ID: 1, Origin: "CAPI", Value: "1.1.1.1", Scope: "ip"},
+			{ID: 2, Origin: "CAPI", Value: "2.2.2.2", Scope: "ip"},
+		},
+	}
+	tr.FilterStreamDecisions(stream)
+
+	// Delete incremental decision, which decrements capiCount
+	stream = &lapi.DecisionStream{
+		Deleted: []lapi.Decision{
+			{ID: 1, Origin: "CAPI", Value: "1.1.1.1"},
+		},
+		New: []lapi.Decision{
+			{ID: 3, Origin: "CAPI", Value: "3.3.3.3", Scope: "ip"},
+		},
+	}
+	kept := tr.FilterStreamDecisions(stream)
+	if len(kept) != 1 {
+		t.Fatalf("expected 1 kept after deletion freed capacity, got %d", len(kept))
+	}
+
+	metrics := tr.GetMetrics()
+	if metrics.CAPICount != 2 {
+		t.Errorf("expected CAPICount=2 (1 remaining + 1 new), got %d", metrics.CAPICount)
+	}
+	if metrics.BaseCount != 0 {
+		t.Errorf("expected BaseCount=0 (no full sync), got %d", metrics.BaseCount)
+	}
+}
+
+func TestStreamTracker_BaselineDeletionDoesNotAffectIncrementalCount(t *testing.T) {
+	// Verify that deleting a baseline (full sync) decision does NOT decrement
+	// capiCount since baseline decisions are not counted as incrementals.
+	tr := New(5, ModeCap, testLogger())
+
+	// Full sync with 3 baseline CAPI decisions
+	fullSyncDecisions := []lapi.Decision{
+		{ID: 1, Origin: "CAPI", Value: "10.0.0.1", Scope: "ip"},
+		{ID: 2, Origin: "CAPI", Value: "10.0.0.2", Scope: "ip"},
+		{ID: 3, Origin: "CAPI", Value: "10.0.0.3", Scope: "ip"},
+	}
+	tr.SetCapFromFullSync(fullSyncDecisions)
+
+	metrics := tr.GetMetrics()
+	if metrics.BaseCount != 3 {
+		t.Errorf("expected BaseCount=3, got %d", metrics.BaseCount)
+	}
+	if metrics.CAPICount != 0 {
+		t.Errorf("expected CAPICount=0, got %d", metrics.CAPICount)
+	}
+
+	// Delete one baseline decision
+	stream := &lapi.DecisionStream{
+		Deleted: []lapi.Decision{
+			{ID: 1, Origin: "CAPI", Value: "10.0.0.1"},
+		},
+	}
+	tr.FilterStreamDecisions(stream)
+
+	metrics = tr.GetMetrics()
+	// BaseCount should decrease (baseline decision removed)
+	if metrics.BaseCount != 2 {
+		t.Errorf("expected BaseCount=2 after baseline deletion, got %d", metrics.BaseCount)
+	}
+	// CAPICount should remain 0 (deleting a baseline doesn't affect incremental count)
+	if metrics.CAPICount != 0 {
+		t.Errorf("expected CAPICount=0 (baseline deletion doesn't affect incrementals), got %d", metrics.CAPICount)
+	}
+
+	// Drop from dedup set — same value can be added again as incremental
+	stream = &lapi.DecisionStream{
+		New: []lapi.Decision{
+			{ID: 100, Origin: "CAPI", Value: "10.0.0.1", Scope: "ip"},
+		},
+	}
+	kept := tr.FilterStreamDecisions(stream)
+	if len(kept) != 1 {
+		t.Errorf("expected 1 kept (value can be re-added), got %d", len(kept))
+	}
+
+	metrics = tr.GetMetrics()
+	if metrics.CAPICount != 1 {
+		t.Errorf("expected CAPICount=1 (re-added as incremental), got %d", metrics.CAPICount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two critical stream tracker bugs in the sidecar and releases v2.5.0.

### Bug #58 — Cap mode silently drops incrementals after full sync exceeding maxDecisions

**Problem**: `SetCapFromFullSync` calls `addTracked` for each baseline CAPI decision, setting `capiCount` to the full-sync count. On devices where a full sync returns more CAPI decisions than `maxDecisions` (e.g., UDM Pro with 20k active vs 15k max), `capiCount` starts already over the cap, silently dropping **every** subsequent incremental decision.

**Fix**: Baseline CAPI decisions from the full sync are now tracked in a separate `fullSyncSet` and are **not counted** in `capiCount`. After `SetCapFromFullSync`, `capiCount` is reset to 0. The cap check (`capiCount < maxDecisions`) only applies to incremental additions. Baseline deletions also correctly don't decrement `capiCount`.

### Bug #57 — Evict mode resets on restart causing mass eviction

**Problem**: On sidecar restart, `SetCapFromFullSync` repopulated the eviction-ordered `tracked` slice with **all** baseline CAPI decisions from the full sync. This meant eviction could replace baseline (authoritative) decisions on the next incremental update, potentially removing decisions that were intentionally in the ipset.

**Fix**: The `tracked` slice is now only populated by `addTracked` (called for incremental decisions only). `SetCapFromFullSync` clears the tracked slice and does not add baseline decisions to it. Eviction only ever replaces incremental decisions.

### Changes
- Add `fullSyncSet` field to `StreamTracker` for baseline decision tracking
- `SetCapFromFullSync`: reset `capiCount=0`, populate `fullSyncSet` for dedup only
- `removeTracked`: only decrement `capiCount` for non-baseline (incremental) deletions
- Add `BaseCount` metric for monitoring baseline vs. incremental counts
- 4 new regression tests + updated existing tests (17 total, all pass)

### Test Results
```
ok  github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/tracker  0.115s
```
Full sidecar suite also passes:
```
ok  github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/tracker
ok  github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/abuseipdb
ok  github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/config
ok  github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/lapi
ok  github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/proxy
ok  github.com/wolffcatskyy/crowdsec-unifi-bouncer/sidecar/internal/scorer
```

Closes #57, Closes #58