### PR TITLE
fix: log-rules.sh persistence via 5-min cron (fixes parser issue \#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **LOG rule persistence on UCG Fiber / UniFi OS 4.x** — `log-rules.sh` now re-applied via 5-min cron (fixes parser issue #7). Previously, LOG rules were only deployed once at install/boot and vanished after a bouncer restart or iptables flush, while DROP rules already self-healed via `ensure-rules.sh`.
+
 ### Added
 - **iptables LOG rules** — `log-rules.sh` inserts LOG rules before every DROP rule in UniFi WAN firewall chains, giving CrowdSec visibility into blocked traffic
   - Enables detection of port scans and brute force from already-blocked IPs

--- a/install.sh
+++ b/install.sh
@@ -87,10 +87,15 @@ systemctl daemon-reload
 
 # Install cron jobs for rule persistence and capacity monitoring
 ENSURE_CRON="*/5 * * * * /data/crowdsec-bouncer/ensure-rules.sh"
+LOG_CRON="*/5 * * * * /data/crowdsec-bouncer/log-rules.sh --quiet"
 CAPACITY_CRON="*/5 * * * * /data/crowdsec-bouncer/ipset-capacity-monitor.sh --check >/dev/null 2>&1"
 if ! crontab -l 2>/dev/null | grep -q ensure-rules.sh; then
     (crontab -l 2>/dev/null; echo "$ENSURE_CRON") | crontab -
     echo "Rule persistence cron job installed."
+fi
+if ! crontab -l 2>/dev/null | grep -q log-rules.sh; then
+    (crontab -l 2>/dev/null; echo "$LOG_CRON") | crontab -
+    echo "LOG rule persistence cron job installed."
 fi
 if ! crontab -l 2>/dev/null | grep -q ipset-capacity-monitor; then
     (crontab -l 2>/dev/null; echo "$CAPACITY_CRON") | crontab -


### PR DESCRIPTION
## Problem

On UCG Fiber / UniFi OS 4.x, a bouncer restart flushes iptables. DROP rules self-heal every 5 minutes via `ensure-rules.sh` cron, but LOG rules (deployed by `log-rules.sh`) were only applied once at install/boot and never recovered — they vanished permanently after a flush.

This was confirmed and closed as `wolffcatskyy/crowdsec-unifi-parser#7`.

## Fix

Added a 5-minute cron job for `log-rules.sh --quiet` in `install.sh`, matching the existing pattern for `ensure-rules.sh` and `ipset-capacity-monitor.sh`. Now LOG rules self-heal on the same cadence as DROP rules.

Boot-time coverage is unchanged — `setup.sh` (via systemd ExecStartPre) already calls `log-rules.sh` at service start.

## Changes

- `install.sh`: Added `LOG_CRON` variable and guarded cron block for `log-rules.sh --quiet`
- `CHANGELOG.md`: Documented fix under `[Unreleased]`
- `bash -n install.sh`: passes syntax check